### PR TITLE
test: add comprehensive testing strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +416,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +490,17 @@ checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -862,6 +903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1078,15 @@ dependencies = [
  "crc32fast",
  "libz-rs-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1878,6 +1934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "now"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,6 +2734,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2779,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2718,6 +2829,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2862,6 +2979,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3160,6 +3286,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3554,6 +3692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,6 +3923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3836,9 +3986,12 @@ name = "unimorph-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "indicatif",
+ "predicates",
  "serde_json",
+ "tempfile",
  "tokio",
  "unimorph-core",
 ]
@@ -3848,6 +4001,7 @@ name = "unimorph-core"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "proptest",
  "reqwest",
  "rusqlite",
  "serde",
@@ -3909,6 +4063,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -19,3 +19,8 @@ anyhow.workspace = true
 tokio.workspace = true
 indicatif.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"

--- a/crates/unimorph-cli/tests/cli.rs
+++ b/crates/unimorph-cli/tests/cli.rs
@@ -1,0 +1,232 @@
+//! CLI integration tests.
+//!
+//! These tests verify the CLI binary behaves correctly.
+
+use assert_cmd::Command;
+use assert_cmd::cargo_bin_cmd;
+use predicates::prelude::*;
+
+fn unimorph() -> Command {
+    cargo_bin_cmd!("unimorph")
+}
+
+mod help {
+    use super::*;
+
+    #[test]
+    fn help_shows_usage() {
+        unimorph()
+            .arg("--help")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Usage:"))
+            .stdout(predicate::str::contains("Commands:"));
+    }
+
+    #[test]
+    fn help_shows_all_commands() {
+        unimorph()
+            .arg("--help")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("download"))
+            .stdout(predicate::str::contains("list"))
+            .stdout(predicate::str::contains("inflect"))
+            .stdout(predicate::str::contains("analyze"))
+            .stdout(predicate::str::contains("stats"))
+            .stdout(predicate::str::contains("delete"));
+    }
+
+    #[test]
+    fn version_shows_version() {
+        unimorph()
+            .arg("--version")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("unimorph"))
+            .stdout(predicate::str::contains("0.1.0"));
+    }
+
+    #[test]
+    fn download_help() {
+        unimorph()
+            .args(["download", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("--force"));
+    }
+
+    #[test]
+    fn inflect_help() {
+        unimorph()
+            .args(["inflect", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("--features"))
+            .stdout(predicate::str::contains("--json"));
+    }
+
+    #[test]
+    fn analyze_help() {
+        unimorph()
+            .args(["analyze", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("--json"));
+    }
+
+    #[test]
+    fn stats_help() {
+        unimorph()
+            .args(["stats", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("--json"));
+    }
+
+    #[test]
+    fn list_help() {
+        unimorph()
+            .args(["list", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("--cached"));
+    }
+
+    #[test]
+    fn delete_help() {
+        unimorph()
+            .args(["delete", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("--lang"));
+    }
+}
+
+mod errors {
+    use super::*;
+
+    #[test]
+    fn missing_command_shows_help() {
+        unimorph()
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Usage:"));
+    }
+
+    #[test]
+    fn unknown_command_shows_error() {
+        unimorph()
+            .arg("unknown")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("error"));
+    }
+
+    #[test]
+    fn download_requires_lang() {
+        unimorph()
+            .arg("download")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--lang"));
+    }
+
+    #[test]
+    fn inflect_requires_lang() {
+        unimorph()
+            .args(["inflect", "parlare"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--lang"));
+    }
+
+    #[test]
+    fn inflect_requires_lemma() {
+        unimorph().args(["inflect", "-l", "ita"]).assert().failure();
+    }
+
+    #[test]
+    fn analyze_requires_lang() {
+        unimorph()
+            .args(["analyze", "parlo"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--lang"));
+    }
+
+    #[test]
+    fn analyze_requires_form() {
+        unimorph().args(["analyze", "-l", "ita"]).assert().failure();
+    }
+
+    #[test]
+    fn stats_requires_lang() {
+        unimorph()
+            .arg("stats")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--lang"));
+    }
+
+    #[test]
+    fn delete_requires_lang() {
+        unimorph()
+            .arg("delete")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--lang"));
+    }
+}
+
+mod list_command {
+    use super::*;
+
+    #[test]
+    fn list_shows_available_info() {
+        unimorph()
+            .arg("list")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("github.com/unimorph"));
+    }
+
+    #[test]
+    fn list_cached_works() {
+        // This test uses the default cache, so results depend on what's downloaded
+        unimorph().args(["list", "--cached"]).assert().success();
+    }
+}
+
+// Tests that require network access or modify state should be marked #[ignore]
+// and run separately with `cargo test -- --ignored`
+mod network_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    #[ignore = "requires network access"]
+    fn download_and_query_workflow() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Download a small dataset (Czech is relatively small)
+        unimorph()
+            .env("HOME", temp_dir.path())
+            .args(["download", "-l", "ces"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Downloaded ces"));
+
+        // Query should work now
+        unimorph()
+            .env("HOME", temp_dir.path())
+            .args(["stats", "-l", "ces"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Total entries"));
+    }
+}

--- a/crates/unimorph-core/Cargo.toml
+++ b/crates/unimorph-core/Cargo.toml
@@ -19,3 +19,5 @@ dirs.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+proptest = "1"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/unimorph-core/tests/integration.rs
+++ b/crates/unimorph-core/tests/integration.rs
@@ -1,0 +1,268 @@
+//! Integration tests for unimorph-core.
+//!
+//! These tests verify complete workflows and interactions between components.
+
+use tempfile::TempDir;
+use unimorph_core::{Entry, LangCode, Repository, Store};
+
+/// Sample Italian verb data for testing.
+const SAMPLE_ITA_DATA: &str = r#"parlare	parlo	V;IND;PRS;1;SG
+parlare	parli	V;IND;PRS;2;SG
+parlare	parla	V;IND;PRS;3;SG
+parlare	parliamo	V;IND;PRS;1;PL
+parlare	parlate	V;IND;PRS;2;PL
+parlare	parlano	V;IND;PRS;3;PL
+essere	sono	V;IND;PRS;1;SG
+essere	sei	V;IND;PRS;2;SG
+essere	è	V;IND;PRS;3;SG
+essere	siamo	V;IND;PRS;1;PL
+essere	siete	V;IND;PRS;2;PL
+essere	sono	V;IND;PRS;3;PL
+"#;
+
+/// Sample German noun data for testing.
+const SAMPLE_DEU_DATA: &str = r#"Haus	Haus	N;NOM;SG
+Haus	Hauses	N;GEN;SG
+Haus	Haus	N;DAT;SG
+Haus	Haus	N;ACC;SG
+Haus	Häuser	N;NOM;PL
+Haus	Häuser	N;GEN;PL
+Haus	Häusern	N;DAT;PL
+Haus	Häuser	N;ACC;PL
+"#;
+
+fn setup_store_with_data(data: &str, lang: &str) -> (TempDir, Store) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let mut store = Store::open(&db_path).unwrap();
+
+    let entries = Entry::parse_tsv(data).unwrap();
+    let lang_code = LangCode::new(lang).unwrap();
+    store.import(&lang_code, &entries, None).unwrap();
+
+    (temp_dir, store)
+}
+
+mod store_integration {
+    use super::*;
+
+    #[test]
+    fn inflect_returns_all_forms() {
+        let (_dir, store) = setup_store_with_data(SAMPLE_ITA_DATA, "ita");
+
+        let forms = store.inflect("ita", "parlare").unwrap();
+        assert_eq!(forms.len(), 6);
+
+        let form_strings: Vec<_> = forms.iter().map(|e| e.form.as_str()).collect();
+        assert!(form_strings.contains(&"parlo"));
+        assert!(form_strings.contains(&"parli"));
+        assert!(form_strings.contains(&"parla"));
+        assert!(form_strings.contains(&"parliamo"));
+        assert!(form_strings.contains(&"parlate"));
+        assert!(form_strings.contains(&"parlano"));
+    }
+
+    #[test]
+    fn analyze_returns_correct_lemma() {
+        let (_dir, store) = setup_store_with_data(SAMPLE_ITA_DATA, "ita");
+
+        let analyses = store.analyze("ita", "parlo").unwrap();
+        assert_eq!(analyses.len(), 1);
+        assert_eq!(analyses[0].lemma, "parlare");
+        assert_eq!(analyses[0].features.as_str(), "V;IND;PRS;1;SG");
+    }
+
+    #[test]
+    fn analyze_handles_ambiguous_forms() {
+        let (_dir, store) = setup_store_with_data(SAMPLE_ITA_DATA, "ita");
+
+        // "sono" appears twice: 1SG and 3PL of "essere"
+        let analyses = store.analyze("ita", "sono").unwrap();
+        assert_eq!(analyses.len(), 2);
+        assert!(analyses.iter().all(|e| e.lemma == "essere"));
+    }
+
+    #[test]
+    fn stats_are_accurate() {
+        let (_dir, store) = setup_store_with_data(SAMPLE_ITA_DATA, "ita");
+
+        let stats = store.stats("ita").unwrap().unwrap();
+        assert_eq!(stats.total_entries, 12);
+        assert_eq!(stats.unique_lemmas, 2); // parlare, essere
+        assert_eq!(stats.unique_forms, 11); // "sono" appears twice
+    }
+
+    #[test]
+    fn multiple_languages_isolated() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let mut store = Store::open(&db_path).unwrap();
+
+        // Import Italian
+        let ita_entries = Entry::parse_tsv(SAMPLE_ITA_DATA).unwrap();
+        let ita = LangCode::new("ita").unwrap();
+        store.import(&ita, &ita_entries, None).unwrap();
+
+        // Import German
+        let deu_entries = Entry::parse_tsv(SAMPLE_DEU_DATA).unwrap();
+        let deu = LangCode::new("deu").unwrap();
+        store.import(&deu, &deu_entries, None).unwrap();
+
+        // Italian queries don't return German data
+        let ita_forms = store.inflect("ita", "Haus").unwrap();
+        assert!(ita_forms.is_empty());
+
+        // German queries don't return Italian data
+        let deu_forms = store.inflect("deu", "parlare").unwrap();
+        assert!(deu_forms.is_empty());
+
+        // Each language has correct stats
+        let ita_stats = store.stats("ita").unwrap().unwrap();
+        let deu_stats = store.stats("deu").unwrap().unwrap();
+        assert_eq!(ita_stats.total_entries, 12);
+        assert_eq!(deu_stats.total_entries, 8);
+
+        // Languages list is correct
+        let langs = store.languages().unwrap();
+        assert_eq!(langs.len(), 2);
+    }
+
+    #[test]
+    fn search_features_exact_match() {
+        let (_dir, store) = setup_store_with_data(SAMPLE_ITA_DATA, "ita");
+
+        let results = store.search_features("ita", "V;IND;PRS;1;SG").unwrap();
+        assert_eq!(results.len(), 2); // parlo, sono
+
+        let forms: Vec<_> = results.iter().map(|e| e.form.as_str()).collect();
+        assert!(forms.contains(&"parlo"));
+        assert!(forms.contains(&"sono"));
+    }
+
+    #[test]
+    fn search_features_with_wildcard() {
+        let (_dir, store) = setup_store_with_data(SAMPLE_ITA_DATA, "ita");
+
+        // All singular forms
+        let results = store.search_features("ita", "V;IND;PRS;*;SG").unwrap();
+        assert_eq!(results.len(), 6); // 3 per verb * 2 verbs
+    }
+
+    #[test]
+    fn delete_language_removes_all_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let mut store = Store::open(&db_path).unwrap();
+
+        let entries = Entry::parse_tsv(SAMPLE_ITA_DATA).unwrap();
+        let lang = LangCode::new("ita").unwrap();
+        store.import(&lang, &entries, None).unwrap();
+
+        assert!(store.has_language("ita").unwrap());
+        assert_eq!(store.stats("ita").unwrap().unwrap().total_entries, 12);
+
+        store.delete_language("ita").unwrap();
+
+        assert!(!store.has_language("ita").unwrap());
+        assert!(store.stats("ita").unwrap().is_none());
+        assert!(store.inflect("ita", "parlare").unwrap().is_empty());
+    }
+
+    #[test]
+    fn reimport_replaces_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let mut store = Store::open(&db_path).unwrap();
+
+        let lang = LangCode::new("ita").unwrap();
+
+        // First import
+        let entries1 = Entry::parse_tsv(SAMPLE_ITA_DATA).unwrap();
+        store.import(&lang, &entries1, None).unwrap();
+        assert_eq!(store.stats("ita").unwrap().unwrap().total_entries, 12);
+
+        // Second import with different data
+        let entries2 = Entry::parse_tsv("nuovo\tnuova\tADJ;FEM;SG\n").unwrap();
+        store.import(&lang, &entries2, None).unwrap();
+        assert_eq!(store.stats("ita").unwrap().unwrap().total_entries, 1);
+
+        // Old data is gone
+        assert!(store.inflect("ita", "parlare").unwrap().is_empty());
+    }
+}
+
+mod repository_integration {
+    use super::*;
+
+    #[test]
+    fn repository_creates_cache_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("unimorph_cache");
+
+        assert!(!cache_path.exists());
+        let _repo = Repository::with_cache_dir(&cache_path).unwrap();
+        assert!(cache_path.exists());
+        assert!(cache_path.join("datasets.db").exists());
+    }
+
+    #[test]
+    fn repository_lists_empty_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::with_cache_dir(temp_dir.path()).unwrap();
+
+        let langs = repo.cached_languages().unwrap();
+        assert!(langs.is_empty());
+    }
+}
+
+mod parsing_edge_cases {
+    use super::*;
+
+    #[test]
+    fn parse_unicode_forms() {
+        let data = "être\tsuis\tV;IND;PRS;1;SG\n";
+        let entries = Entry::parse_tsv(data).unwrap();
+        assert_eq!(entries[0].lemma, "être");
+        assert_eq!(entries[0].form, "suis");
+    }
+
+    #[test]
+    fn parse_unicode_with_diacritics() {
+        let data = "ação\tações\tN;PL\n";
+        let entries = Entry::parse_tsv(data).unwrap();
+        assert_eq!(entries[0].lemma, "ação");
+        assert_eq!(entries[0].form, "ações");
+    }
+
+    #[test]
+    fn parse_cyrillic() {
+        let data = "говорить\tговорю\tV;IND;PRS;1;SG\n";
+        let entries = Entry::parse_tsv(data).unwrap();
+        assert_eq!(entries[0].lemma, "говорить");
+        assert_eq!(entries[0].form, "говорю");
+    }
+
+    #[test]
+    fn parse_arabic() {
+        let data = "كتب\tيكتب\tV;IND;PRS;3;SG;MASC\n";
+        let entries = Entry::parse_tsv(data).unwrap();
+        assert_eq!(entries[0].lemma, "كتب");
+        assert_eq!(entries[0].form, "يكتب");
+    }
+
+    #[test]
+    fn parse_lenient_skips_bad_lines() {
+        let data = "good\tentry\tV;IND\nbad line\nanother\tgood\tN;SG\n";
+        let (entries, skipped) = Entry::parse_tsv_lenient(data);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(skipped, 1);
+    }
+
+    #[test]
+    fn parse_lenient_handles_empty_lines() {
+        let data = "good\tentry\tV;IND\n\n\nanother\tgood\tN;SG\n";
+        let (entries, skipped) = Entry::parse_tsv_lenient(data);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(skipped, 0);
+    }
+}

--- a/crates/unimorph-core/tests/proptest.rs
+++ b/crates/unimorph-core/tests/proptest.rs
@@ -1,0 +1,177 @@
+//! Property-based tests for unimorph-core.
+//!
+//! These tests use proptest to generate random inputs and verify
+//! that invariants hold across all inputs.
+
+use proptest::prelude::*;
+use unimorph_core::{Entry, FeatureBundle, LangCode};
+
+/// Strategy for generating valid ISO 639-3 language codes.
+fn lang_code_strategy() -> impl Strategy<Value = String> {
+    "[a-z]{3}".prop_map(|s| s.to_string())
+}
+
+/// Strategy for generating valid feature strings (single feature).
+fn feature_strategy() -> impl Strategy<Value = String> {
+    // Features are uppercase letters, digits, and dots
+    "[A-Z0-9.]{1,10}".prop_map(|s| s.to_string())
+}
+
+/// Strategy for generating valid feature bundles.
+fn feature_bundle_strategy() -> impl Strategy<Value = String> {
+    prop::collection::vec(feature_strategy(), 1..=8).prop_map(|features| features.join(";"))
+}
+
+/// Strategy for generating valid lemmas/forms (non-empty Unicode strings).
+fn word_strategy() -> impl Strategy<Value = String> {
+    "[\\p{L}]{1,30}".prop_map(|s| s.to_string())
+}
+
+/// Strategy for generating valid TSV lines.
+fn tsv_line_strategy() -> impl Strategy<Value = String> {
+    (word_strategy(), word_strategy(), feature_bundle_strategy())
+        .prop_map(|(lemma, form, features)| format!("{}\t{}\t{}", lemma, form, features))
+}
+
+proptest! {
+    /// Any 3-letter lowercase ASCII string is a valid language code.
+    #[test]
+    fn valid_lang_codes_parse(code in lang_code_strategy()) {
+        let result = LangCode::new(&code);
+        prop_assert!(result.is_ok(), "Failed to parse: {}", code);
+        let lang_code = result.unwrap();
+        prop_assert_eq!(lang_code.as_str(), code);
+    }
+
+    /// Invalid language codes are rejected.
+    #[test]
+    fn invalid_lang_codes_rejected(code in "[A-Za-z0-9]{0,10}") {
+        // Skip valid codes (exactly 3 lowercase)
+        if code.len() == 3 && code.chars().all(|c| c.is_ascii_lowercase()) {
+            return Ok(());
+        }
+        let result = LangCode::new(&code);
+        prop_assert!(result.is_err(), "Should have rejected: {}", code);
+    }
+
+    /// Any valid feature bundle string parses correctly.
+    #[test]
+    fn valid_feature_bundles_parse(bundle_str in feature_bundle_strategy()) {
+        let result = FeatureBundle::new(&bundle_str);
+        prop_assert!(result.is_ok(), "Failed to parse: {}", bundle_str);
+
+        let bundle = result.unwrap();
+        prop_assert_eq!(bundle.as_str(), bundle_str);
+    }
+
+    /// Parsed feature bundles round-trip correctly.
+    #[test]
+    fn feature_bundle_roundtrip(bundle_str in feature_bundle_strategy()) {
+        let bundle = FeatureBundle::new(&bundle_str).unwrap();
+        let features = bundle.features();
+
+        // Rejoining should give original string
+        let rejoined = features.join(";");
+        prop_assert_eq!(rejoined, bundle_str);
+    }
+
+    /// Feature bundle contains() is consistent with features().
+    #[test]
+    fn feature_bundle_contains_consistent(bundle_str in feature_bundle_strategy()) {
+        let bundle = FeatureBundle::new(&bundle_str).unwrap();
+
+        for feature in bundle.features() {
+            prop_assert!(
+                bundle.contains(feature),
+                "Bundle should contain its own feature: {}",
+                feature
+            );
+        }
+    }
+
+    /// A bundle always matches its exact pattern.
+    #[test]
+    fn feature_bundle_matches_self(bundle_str in feature_bundle_strategy()) {
+        let bundle = FeatureBundle::new(&bundle_str).unwrap();
+        prop_assert!(
+            bundle.matches_pattern(&bundle_str),
+            "Bundle should match itself"
+        );
+    }
+
+    /// A bundle matches an all-wildcard pattern of the same length.
+    #[test]
+    fn feature_bundle_matches_wildcards(bundle_str in feature_bundle_strategy()) {
+        let bundle = FeatureBundle::new(&bundle_str).unwrap();
+        let wildcard_pattern = vec!["*"; bundle.len()].join(";");
+
+        prop_assert!(
+            bundle.matches_pattern(&wildcard_pattern),
+            "Bundle should match all-wildcard pattern"
+        );
+    }
+
+    /// Valid TSV lines parse correctly.
+    #[test]
+    fn valid_tsv_lines_parse(line in tsv_line_strategy()) {
+        let result = Entry::parse_line(&line, 1);
+        prop_assert!(result.is_ok(), "Failed to parse: {}", line);
+
+        let entry = result.unwrap();
+        // Check round-trip via Display
+        let displayed = format!("{}", entry);
+        prop_assert_eq!(displayed, line);
+    }
+
+    /// Entry fields are preserved after parsing.
+    #[test]
+    fn entry_preserves_fields(
+        lemma in word_strategy(),
+        form in word_strategy(),
+        features in feature_bundle_strategy()
+    ) {
+        let line = format!("{}\t{}\t{}", lemma, form, features);
+        let entry = Entry::parse_line(&line, 1).unwrap();
+
+        prop_assert_eq!(entry.lemma, lemma);
+        prop_assert_eq!(entry.form, form);
+        prop_assert_eq!(entry.features.as_str(), features);
+    }
+}
+
+#[cfg(test)]
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn empty_feature_bundle_rejected() {
+        assert!(FeatureBundle::new("").is_err());
+    }
+
+    #[test]
+    fn feature_bundle_with_empty_feature_rejected() {
+        assert!(FeatureBundle::new("V;;PRS").is_err());
+        assert!(FeatureBundle::new(";V;PRS").is_err());
+        assert!(FeatureBundle::new("V;PRS;").is_err());
+    }
+
+    #[test]
+    fn tsv_line_wrong_columns() {
+        assert!(Entry::parse_line("one", 1).is_err());
+        assert!(Entry::parse_line("one\ttwo", 1).is_err());
+        assert!(Entry::parse_line("one\ttwo\tthree\tfour", 1).is_err());
+    }
+
+    #[test]
+    fn tsv_line_empty_fields() {
+        assert!(Entry::parse_line("\tform\tV;IND", 1).is_err());
+        assert!(Entry::parse_line("lemma\t\tV;IND", 1).is_err());
+    }
+
+    #[test]
+    fn feature_pattern_wrong_length_never_matches() {
+        let bundle = FeatureBundle::new("V;IND;PRS").unwrap();
+        assert!(!bundle.matches_pattern("V;IND"));
+        assert!(!bundle.matches_pattern("V;IND;PRS;SG"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements comprehensive testing strategy for unimorph-rs.

## Changes

### Property-based tests (proptest)
- LangCode parsing and validation (valid/invalid codes)
- FeatureBundle roundtrip, matching, and containment
- Entry TSV parsing and field preservation
- Edge cases for malformed input

### Integration tests
- Store workflows (inflect, analyze, search, stats)
- Multi-language data isolation
- Unicode handling (Cyrillic, Arabic, diacritics)
- Delete and reimport operations

### CLI tests (assert_cmd)
- Help text verification for all commands
- Error message validation
- Argument requirement checks
- List command functionality

## Test Results

- 14 property-based tests
- 17 integration tests  
- 20 CLI tests (1 ignored - requires network)
- All existing 74 unit tests still pass

Closes #10