### PR TITLE
feat: add tracing support and improve error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,18 +138,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "ar_archive_writer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
 dependencies = [
- "object",
+ "object 0.32.2",
 ]
 
 [[package]]
@@ -408,6 +411,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base64"
@@ -686,6 +704,33 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1028,6 +1073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1301,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1607,6 +1668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1765,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexical-core"
@@ -1875,6 +1948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2037,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2047,6 +2138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2213,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking_lot"
@@ -3228,6 +3334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3523,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3718,6 +3839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,7 +4034,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3914,6 +4056,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3985,14 +4167,16 @@ dependencies = [
 name = "unimorph-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "clap",
+ "color-eyre",
  "indicatif",
  "predicates",
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "unimorph-core",
 ]
 
@@ -4009,6 +4193,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4051,6 +4236,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,10 @@ anyhow = "1"
 # Utilities
 dirs = "6"
 indicatif = "0.17"
+
+# Tracing/logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Better errors
+color-eyre = "0.6"

--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -15,10 +15,12 @@ path = "src/main.rs"
 [dependencies]
 unimorph-core = { path = "../unimorph-core" }
 clap.workspace = true
-anyhow.workspace = true
 tokio.workspace = true
 indicatif.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+color-eyre.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -1,8 +1,12 @@
 //! UniMorph CLI - Command-line interface for UniMorph morphological data.
 
-use anyhow::{Context, Result};
+use std::io::{self, IsTerminal};
+
 use clap::{Parser, Subcommand};
+use color_eyre::eyre::{Context, ContextCompat, Result, eyre};
 use indicatif::{ProgressBar, ProgressStyle};
+use tracing::{debug, info, instrument};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use unimorph_core::Repository;
 
@@ -10,6 +14,14 @@ use unimorph_core::Repository;
 #[command(name = "unimorph")]
 #[command(author, version, about = "Work with UniMorph morphological data", long_about = None)]
 struct Cli {
+    /// Enable verbose output (-v for debug, -vv for trace)
+    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
+    verbose: u8,
+
+    /// Suppress non-essential output
+    #[arg(short, long, global = true)]
+    quiet: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -85,12 +97,37 @@ enum Commands {
     },
 }
 
+fn init_tracing(verbose: u8) {
+    let filter = match verbose {
+        0 => EnvFilter::new("warn"),
+        1 => EnvFilter::new("info,unimorph_core=debug,unimorph_cli=debug"),
+        _ => EnvFilter::new("debug,unimorph_core=trace,unimorph_cli=trace"),
+    };
+
+    // Use RUST_LOG env var if set, otherwise use verbose flag
+    let filter = EnvFilter::try_from_default_env().unwrap_or(filter);
+
+    tracing_subscriber::registry()
+        .with(fmt::layer().with_target(verbose > 1))
+        .with(filter)
+        .init();
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let cli = Cli::parse();
+    init_tracing(cli.verbose);
+
+    debug!(
+        verbose = cli.verbose,
+        quiet = cli.quiet,
+        "starting unimorph CLI"
+    );
 
     match cli.command {
-        Commands::Download { lang, force } => cmd_download(&lang, force).await,
+        Commands::Download { lang, force } => cmd_download(&lang, force, cli.quiet).await,
         Commands::List { cached } => cmd_list(cached),
         Commands::Inflect {
             lang,
@@ -104,34 +141,102 @@ async fn main() -> Result<()> {
     }
 }
 
-async fn cmd_download(lang: &str, force: bool) -> Result<()> {
+/// Validate a language code and provide helpful error messages.
+fn validate_lang_code(lang: &str) -> Result<()> {
+    if lang.len() != 3 {
+        return Err(eyre!(
+            "Invalid language code: '{}'\n\n\
+            Language codes must be exactly 3 lowercase letters (ISO 639-3).\n\
+            Examples: ita (Italian), deu (German), fin (Finnish)\n\n\
+            See https://iso639-3.sil.org/code_tables/639/data for the full list.",
+            lang
+        ));
+    }
+
+    if !lang.chars().all(|c| c.is_ascii_lowercase()) {
+        let suggestion = lang.to_lowercase();
+        return Err(eyre!(
+            "Invalid language code: '{}'\n\n\
+            Language codes must be lowercase. Did you mean '{}'?",
+            lang,
+            suggestion
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a language is downloaded, with a helpful error if not.
+fn require_language(repo: &Repository, lang: &str) -> Result<()> {
+    if !repo.store().has_language(lang)? {
+        return Err(eyre!(
+            "Language '{}' is not downloaded.\n\n\
+            To download it, run:\n\
+            \n    unimorph download -l {}\n\n\
+            To see what's cached:\n\
+            \n    unimorph list --cached",
+            lang,
+            lang
+        ));
+    }
+    Ok(())
+}
+
+#[instrument(skip_all, fields(lang, force))]
+async fn cmd_download(lang: &str, force: bool, quiet: bool) -> Result<()> {
+    validate_lang_code(lang)?;
+
     let mut repo = Repository::new().context("Failed to initialize repository")?;
 
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} {msg}")
-            .expect("valid template"),
-    );
-    pb.set_message(format!("Downloading {}...", lang));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
-
-    let downloaded = if force {
-        repo.refresh(lang).await.context("Download failed")?;
-        true
+    let is_terminal = io::stdout().is_terminal();
+    let pb = if !quiet && is_terminal {
+        let pb = ProgressBar::new_spinner();
+        pb.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .expect("valid template"),
+        );
+        pb.set_message(format!("Downloading {}...", lang));
+        pb.enable_steady_tick(std::time::Duration::from_millis(100));
+        Some(pb)
     } else {
-        repo.ensure(lang).await.context("Download failed")?
+        None
     };
 
-    pb.finish_and_clear();
+    let downloaded = if force {
+        repo.refresh(lang)
+            .await
+            .context(format!("Failed to download '{}'", lang))?;
+        true
+    } else {
+        repo.ensure(lang)
+            .await
+            .context(format!("Failed to download '{}'", lang))?
+    };
+
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
+    }
 
     if downloaded {
-        let stats = repo.store().stats(lang)?.context("Failed to get stats")?;
-        println!(
-            "Downloaded {}: {} entries, {} lemmas, {} forms",
-            lang, stats.total_entries, stats.unique_lemmas, stats.unique_forms
+        let stats = repo
+            .store()
+            .stats(lang)?
+            .context("Failed to retrieve stats after download")?;
+        info!(
+            lang,
+            entries = stats.total_entries,
+            lemmas = stats.unique_lemmas,
+            forms = stats.unique_forms,
+            "download complete"
         );
-    } else {
+        if !quiet {
+            println!(
+                "Downloaded {}: {} entries, {} lemmas, {} forms",
+                lang, stats.total_entries, stats.unique_lemmas, stats.unique_forms
+            );
+        }
+    } else if !quiet {
         println!("{} is already cached. Use --force to re-download.", lang);
     }
 
@@ -144,7 +249,14 @@ fn cmd_list(cached: bool) -> Result<()> {
     if cached {
         let langs = repo.cached_languages()?;
         if langs.is_empty() {
-            println!("No languages cached. Use 'unimorph download -l <lang>' to download.");
+            println!("No languages cached.");
+            println!();
+            println!("To download a language:");
+            println!("  unimorph download -l <lang>");
+            println!();
+            println!("Examples:");
+            println!("  unimorph download -l ita   # Italian");
+            println!("  unimorph download -l deu   # German");
         } else {
             println!("Cached languages:");
             for lang in langs {
@@ -157,7 +269,6 @@ fn cmd_list(cached: bool) -> Result<()> {
             }
         }
     } else {
-        // TODO: Fetch available languages from GitHub API
         println!("Available languages: https://github.com/unimorph");
         println!();
         println!("Common languages:");
@@ -176,16 +287,12 @@ fn cmd_list(cached: bool) -> Result<()> {
     Ok(())
 }
 
+#[instrument(skip_all, fields(lang, lemma))]
 fn cmd_inflect(lang: &str, lemma: &str, features: Option<&str>, json: bool) -> Result<()> {
-    let repo = Repository::new().context("Failed to initialize repository")?;
+    validate_lang_code(lang)?;
 
-    if !repo.store().has_language(lang)? {
-        anyhow::bail!(
-            "Language '{}' not found. Download it first with: unimorph download -l {}",
-            lang,
-            lang
-        );
-    }
+    let repo = Repository::new().context("Failed to initialize repository")?;
+    require_language(&repo, lang)?;
 
     let entries = repo.store().inflect(lang, lemma)?;
 
@@ -199,14 +306,23 @@ fn cmd_inflect(lang: &str, lemma: &str, features: Option<&str>, json: bool) -> R
         entries
     };
 
+    debug!(count = entries.len(), "found forms");
+
     if entries.is_empty() {
         if features.is_some() {
             println!(
                 "No forms found for '{}' matching the feature pattern.",
                 lemma
             );
+            println!();
+            println!(
+                "Tip: Use 'unimorph inflect -l {} {}' without --features to see all forms.",
+                lang, lemma
+            );
         } else {
             println!("No forms found for '{}'.", lemma);
+            println!();
+            println!("The lemma may not exist in the dataset, or it might be spelled differently.");
         }
         return Ok(());
     }
@@ -226,21 +342,24 @@ fn cmd_inflect(lang: &str, lemma: &str, features: Option<&str>, json: bool) -> R
     Ok(())
 }
 
+#[instrument(skip_all, fields(lang, form))]
 fn cmd_analyze(lang: &str, form: &str, json: bool) -> Result<()> {
-    let repo = Repository::new().context("Failed to initialize repository")?;
+    validate_lang_code(lang)?;
 
-    if !repo.store().has_language(lang)? {
-        anyhow::bail!(
-            "Language '{}' not found. Download it first with: unimorph download -l {}",
-            lang,
-            lang
-        );
-    }
+    let repo = Repository::new().context("Failed to initialize repository")?;
+    require_language(&repo, lang)?;
 
     let entries = repo.store().analyze(lang, form)?;
 
+    debug!(count = entries.len(), "found analyses");
+
     if entries.is_empty() {
         println!("No analyses found for '{}'.", form);
+        println!();
+        println!("The form may not exist in the dataset, or it could be:");
+        println!("  - A proper noun or foreign word");
+        println!("  - A misspelling");
+        println!("  - A rare or archaic form");
         return Ok(());
     }
 
@@ -259,18 +378,17 @@ fn cmd_analyze(lang: &str, form: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
+#[instrument(skip_all, fields(lang))]
 fn cmd_stats(lang: &str, json: bool) -> Result<()> {
+    validate_lang_code(lang)?;
+
     let repo = Repository::new().context("Failed to initialize repository")?;
+    require_language(&repo, lang)?;
 
-    if !repo.store().has_language(lang)? {
-        anyhow::bail!(
-            "Language '{}' not found. Download it first with: unimorph download -l {}",
-            lang,
-            lang
-        );
-    }
-
-    let stats = repo.store().stats(lang)?.context("Failed to get stats")?;
+    let stats = repo
+        .store()
+        .stats(lang)?
+        .context("Failed to retrieve statistics")?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&stats)?);
@@ -289,7 +407,10 @@ fn cmd_stats(lang: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
+#[instrument(skip_all, fields(lang))]
 fn cmd_delete(lang: &str) -> Result<()> {
+    validate_lang_code(lang)?;
+
     let mut repo = Repository::new().context("Failed to initialize repository")?;
 
     if !repo.store().has_language(lang)? {
@@ -298,6 +419,7 @@ fn cmd_delete(lang: &str) -> Result<()> {
     }
 
     repo.delete(lang)?;
+    info!(lang, "deleted language");
     println!("Deleted {}.", lang);
 
     Ok(())

--- a/crates/unimorph-core/Cargo.toml
+++ b/crates/unimorph-core/Cargo.toml
@@ -16,6 +16,7 @@ serde_json.workspace = true
 tokio.workspace = true
 reqwest.workspace = true
 dirs.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/unimorph-core/src/repository.rs
+++ b/crates/unimorph-core/src/repository.rs
@@ -29,6 +29,8 @@
 
 use std::path::{Path, PathBuf};
 
+use tracing::{debug, info, instrument, warn};
+
 use crate::{Entry, Error, LangCode, Result, Store};
 
 const UNIMORPH_RAW_URL: &str = "https://raw.githubusercontent.com/unimorph";
@@ -48,6 +50,7 @@ impl Repository {
     /// - Linux: `~/.cache/unimorph/`
     /// - macOS: `~/Library/Caches/unimorph/`
     /// - Windows: `%LOCALAPPDATA%\unimorph\`
+    #[instrument(level = "debug")]
     pub fn new() -> Result<Self> {
         let cache_dir = dirs::cache_dir()
             .ok_or_else(|| Error::CacheDir {
@@ -56,6 +59,7 @@ impl Repository {
             })?
             .join("unimorph");
 
+        debug!(cache_dir = %cache_dir.display(), "using default cache directory");
         Self::with_cache_dir(cache_dir)
     }
 
@@ -97,13 +101,16 @@ impl Repository {
     /// 2. If not, download from GitHub and import
     ///
     /// Returns `true` if the dataset was downloaded, `false` if it was already cached.
+    #[instrument(level = "info", skip(self))]
     pub async fn ensure(&mut self, lang: &str) -> Result<bool> {
         let lang_code = LangCode::new(lang)?;
 
         if self.store.has_language(lang)? {
+            debug!(lang, "language already cached");
             return Ok(false);
         }
 
+        info!(lang, "downloading language dataset");
         self.download_and_import(&lang_code).await?;
         Ok(true)
     }
@@ -112,28 +119,41 @@ impl Repository {
     ///
     /// This will download the latest data from GitHub even if the language
     /// is already in the store.
+    #[instrument(level = "info", skip(self))]
     pub async fn refresh(&mut self, lang: &str) -> Result<()> {
         let lang_code = LangCode::new(lang)?;
+        info!(lang, "refreshing language dataset");
         self.download_and_import(&lang_code).await
     }
 
     /// Download and import a language dataset.
+    #[instrument(level = "debug", skip(self))]
     async fn download_and_import(&mut self, lang: &LangCode) -> Result<()> {
         let content = download_language(lang).await?;
         let (entries, skipped) = Entry::parse_tsv_lenient(&content);
 
         if skipped > 0 {
-            // Log but don't fail - real datasets have some malformed entries
-            eprintln!(
-                "Warning: skipped {} malformed entries for {}",
+            warn!(
+                lang = %lang,
                 skipped,
-                lang.as_str()
+                "skipped malformed entries during import"
             );
         }
+
+        debug!(
+            lang = %lang,
+            entries = entries.len(),
+            "parsed entries from downloaded data"
+        );
 
         let source_url = format!("https://github.com/unimorph/{}", lang.as_str());
 
         self.store.import(lang, &entries, Some(&source_url))?;
+        info!(
+            lang = %lang,
+            entries = entries.len(),
+            "imported language dataset"
+        );
         Ok(())
     }
 
@@ -162,23 +182,28 @@ fn get_file_patterns(lang: &LangCode) -> Vec<String> {
 }
 
 /// Download a language dataset from GitHub.
+#[instrument(level = "debug")]
 async fn download_language(lang: &LangCode) -> Result<String> {
     let client = reqwest::Client::new();
     let patterns = get_file_patterns(lang);
     let mut all_content = String::new();
     let mut found_any = false;
 
+    debug!(lang = %lang, patterns = ?patterns, "downloading from GitHub");
+
     for pattern in &patterns {
         let url = format!("{}/{}/master/{}", UNIMORPH_RAW_URL, lang.as_str(), pattern);
 
+        debug!(url = %url, "fetching file");
         let response = client.get(&url).send().await?;
 
         if response.status() == reqwest::StatusCode::FORBIDDEN {
+            warn!(lang = %lang, "GitHub rate limit exceeded");
             return Err(Error::RateLimited);
         }
 
         if response.status() == reqwest::StatusCode::NOT_FOUND {
-            // Try without the pattern (some repos use different naming)
+            debug!(url = %url, "file not found, trying next pattern");
             continue;
         }
 
@@ -191,6 +216,8 @@ async fn download_language(lang: &LangCode) -> Result<String> {
         }
 
         let content = response.text().await?;
+        let bytes = content.len();
+        debug!(url = %url, bytes, "downloaded file");
         all_content.push_str(&content);
         if !content.ends_with('\n') {
             all_content.push('\n');

--- a/crates/unimorph-core/src/store.rs
+++ b/crates/unimorph-core/src/store.rs
@@ -31,6 +31,7 @@
 use std::path::Path;
 
 use rusqlite::{Connection, params};
+use tracing::{debug, instrument};
 
 use crate::{DatasetStats, Entry, FeatureBundle, LangCode, Result};
 
@@ -111,6 +112,7 @@ impl Store {
     /// Import entries for a language, replacing any existing data.
     ///
     /// This computes and caches statistics in the `meta` table.
+    #[instrument(level = "debug", skip(self, entries), fields(entry_count = entries.len()))]
     pub fn import(
         &mut self,
         lang: &LangCode,
@@ -164,6 +166,7 @@ impl Store {
     ///
     /// This is the "inflect" operation: given a lemma like "parlare",
     /// return all its forms (parlo, parli, parla, ...).
+    #[instrument(level = "debug", skip(self))]
     pub fn inflect(&self, lang: &str, lemma: &str) -> Result<Vec<Entry>> {
         let mut stmt = self
             .conn
@@ -192,6 +195,7 @@ impl Store {
     ///
     /// This is the "analyze" operation: given a form like "parlo",
     /// return all possible analyses (parlare -> parlo, ...).
+    #[instrument(level = "debug", skip(self))]
     pub fn analyze(&self, lang: &str, form: &str) -> Result<Vec<Entry>> {
         let mut stmt = self
             .conn
@@ -277,7 +281,9 @@ impl Store {
     ///
     /// For better performance on large datasets, consider using
     /// `inflect` or `analyze` first, then filtering the results.
+    #[instrument(level = "debug", skip(self))]
     pub fn search_features(&self, lang: &str, pattern: &str) -> Result<Vec<Entry>> {
+        debug!(pattern, "searching features with pattern");
         // Convert pattern to SQL LIKE pattern
         // V;IND;*;1;* -> V;IND;%;1;%
         let sql_pattern = pattern.replace('*', "%");


### PR DESCRIPTION
## Summary

Adds comprehensive tracing/logging support and significantly improves error messages for better user experience, especially for researchers who may be less familiar with CLIs.

## Changes

### Tracing Support
- Added `tracing` instrumentation to core library (repository, store operations)
- CLI now supports `-v` (debug) and `-vv` (trace) verbose flags
- Respects `RUST_LOG` environment variable for fine-grained control

### Improved Error Messages
- Replaced `anyhow` with `color-eyre` for colored, structured error output
- Language code validation with helpful suggestions:
  - Wrong case: `'ITA' -> Did you mean 'ita'?`
  - Wrong length: Links to ISO 639-3 reference
- Missing language errors include download instructions
- Empty query results include troubleshooting tips

### UX Improvements
- Added `--quiet` flag to suppress non-essential output
- Progress spinner only shows in terminal (not when piped)
- Consistent, actionable error messages throughout

## Examples

```bash
$ unimorph inflect -l ITA parlo
Error: Invalid language code: 'ITA'
       Language codes must be lowercase. Did you mean 'ita'?

$ unimorph inflect -l xyz parlo  
Error: Language 'xyz' is not downloaded.
       To download it, run:
           unimorph download -l xyz

$ unimorph -v download -l ita
2026-01-05T22:05:58.900743Z DEBUG downloading language dataset lang="ita"
...
```

Closes #11