### PR TITLE
ci: add release-plz and git-cliff for automated releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,29 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+# git-cliff configuration for changelog generation
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = """
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+    { body = ".*security", group = "Security" },
+]
+protect_breaking_commits = false
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"

--- a/crates/unimorph-bench/Cargo.toml
+++ b/crates/unimorph-bench/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Storage backend benchmarks for unimorph-rs"
+publish = false
 
 [dependencies]
 rusqlite.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+# Use git-cliff for changelog generation
+changelog_config = "cliff.toml"
+# Create GitHub releases
+git_release_enable = true
+# Include commit body in release notes
+git_release_body = true
+
+# Don't publish the benchmark crate
+[[package]]
+name = "unimorph-bench"
+publish = false
+changelog_update = false
+git_release_enable = false


### PR DESCRIPTION
## Summary

Sets up automated release management with release-plz and git-cliff.

## Changes

- **release-plz.yml**: GitHub Actions workflow that runs on pushes to main
  - Creates release PRs with version bumps based on conventional commits
  - Publishes to crates.io when release PRs are merged
  - Creates GitHub releases with changelogs

- **cliff.toml**: git-cliff configuration for changelog generation
  - Groups commits by type (features, bug fixes, etc.)
  - Follows conventional commits format
  - Skips release and dependency update commits

- **release-plz.toml**: Configuration for release-plz
  - Uses git-cliff for changelog generation
  - Enables GitHub releases
  - Excludes unimorph-bench from publishing

- **unimorph-bench/Cargo.toml**: Mark as `publish = false`

## Setup Required

After merging, you'll need to add a `CARGO_REGISTRY_TOKEN` secret to the repository for crates.io publishing.