### PR TITLE
refactor: improve CLI UX with positional arguments

### DIFF
--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "Command-line interface for UniMorph morphological data"
 keywords = ["linguistics", "morphology", "nlp", "unimorph", "cli"]
 categories = ["command-line-utilities", "science", "text-processing"]
+default-run = "unimorph"
 
 [[bin]]
 name = "unimorph"

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -42,7 +42,6 @@ enum Commands {
     /// Download a language dataset
     Download {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        #[arg(short, long)]
         lang: String,
 
         /// Force re-download even if cached
@@ -71,8 +70,7 @@ enum Commands {
 
     /// Look up all forms of a lemma (dictionary form)
     Inflect {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
 
         /// Lemma to look up
@@ -89,8 +87,7 @@ enum Commands {
 
     /// Analyze a surface form (reverse lookup)
     Analyze {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
 
         /// Form to analyze
@@ -103,8 +100,7 @@ enum Commands {
 
     /// Show dataset statistics
     Stats {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
 
         /// Output as JSON
@@ -114,15 +110,13 @@ enum Commands {
 
     /// Delete a cached language dataset
     Delete {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
     },
 
     /// Search entries with flexible filtering
     Search {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
 
         /// Filter by lemma (supports SQL LIKE wildcards: % and _)
@@ -160,8 +154,7 @@ enum Commands {
 
     /// Export a language dataset to file
     Export {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
 
         /// Output file path (use - for stdout)
@@ -181,8 +174,7 @@ enum Commands {
 
     /// Show detailed info about a cached language
     Info {
-        /// Language code
-        #[arg(short, long)]
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
 
         /// Output as JSON
@@ -192,8 +184,7 @@ enum Commands {
 
     /// Update cached language datasets
     Update {
-        /// Language code (omit for --all)
-        #[arg(short, long)]
+        /// Language code (omit with --all to update all)
         lang: Option<String>,
 
         /// Update all cached languages

--- a/crates/unimorph-cli/tests/cli.rs
+++ b/crates/unimorph-cli/tests/cli.rs
@@ -53,7 +53,7 @@ mod help {
             .args(["download", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("<LANG>"))
             .stdout(predicate::str::contains("--force"));
     }
 
@@ -63,7 +63,8 @@ mod help {
             .args(["inflect", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("<LANG>"))
+            .stdout(predicate::str::contains("<LEMMA>"))
             .stdout(predicate::str::contains("--features"))
             .stdout(predicate::str::contains("--json"));
     }
@@ -74,7 +75,8 @@ mod help {
             .args(["analyze", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("<LANG>"))
+            .stdout(predicate::str::contains("<FORM>"))
             .stdout(predicate::str::contains("--json"));
     }
 
@@ -84,7 +86,7 @@ mod help {
             .args(["stats", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("--lang"))
+            .stdout(predicate::str::contains("<LANG>"))
             .stdout(predicate::str::contains("--json"));
     }
 
@@ -103,7 +105,7 @@ mod help {
             .args(["delete", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("--lang"));
+            .stdout(predicate::str::contains("<LANG>"));
     }
 }
 
@@ -133,35 +135,35 @@ mod errors {
             .arg("download")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--lang"));
+            .stderr(predicate::str::contains("<LANG>"));
     }
 
     #[test]
     fn inflect_requires_lang() {
         unimorph()
-            .args(["inflect", "parlare"])
+            .arg("inflect")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--lang"));
+            .stderr(predicate::str::contains("<LANG>"));
     }
 
     #[test]
     fn inflect_requires_lemma() {
-        unimorph().args(["inflect", "-l", "ita"]).assert().failure();
+        unimorph().args(["inflect", "ita"]).assert().failure();
     }
 
     #[test]
     fn analyze_requires_lang() {
         unimorph()
-            .args(["analyze", "parlo"])
+            .arg("analyze")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--lang"));
+            .stderr(predicate::str::contains("<LANG>"));
     }
 
     #[test]
     fn analyze_requires_form() {
-        unimorph().args(["analyze", "-l", "ita"]).assert().failure();
+        unimorph().args(["analyze", "ita"]).assert().failure();
     }
 
     #[test]
@@ -170,7 +172,7 @@ mod errors {
             .arg("stats")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--lang"));
+            .stderr(predicate::str::contains("<LANG>"));
     }
 
     #[test]
@@ -179,7 +181,7 @@ mod errors {
             .arg("delete")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("--lang"));
+            .stderr(predicate::str::contains("<LANG>"));
     }
 }
 
@@ -216,7 +218,7 @@ mod network_tests {
         // Download a small dataset (Czech is relatively small)
         unimorph()
             .env("HOME", temp_dir.path())
-            .args(["download", "-l", "ces"])
+            .args(["download", "ces"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Downloaded ces"));
@@ -224,7 +226,7 @@ mod network_tests {
         // Query should work now
         unimorph()
             .env("HOME", temp_dir.path())
-            .args(["stats", "-l", "ces"])
+            .args(["stats", "ces"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Total entries"));


### PR DESCRIPTION
Improves CLI ergonomics by switching required arguments from flags to positional arguments.

## Changes

### Positional Arguments
Commands now use cleaner positional syntax:

```bash
# Before
unimorph download --lang heb
unimorph inflect --lang heb katav
unimorph analyze --lang heb word

# After
unimorph download heb
unimorph inflect heb katav
unimorph analyze heb word
```

### Affected Commands
- `download <LANG>`
- `stats <LANG>`
- `delete <LANG>`
- `info <LANG>`
- `export <LANG>`
- `search <LANG>`
- `inflect <LANG> <LEMMA>`
- `analyze <LANG> <FORM>`
- `update [LANG]` (optional, can use --all instead)

### Other Improvements
- Added `default-run = "unimorph"` to Cargo.toml for easier `cargo run` usage
- Consistent help text showing ISO 639-3 examples (heb, vec, deu)
- Updated CLI tests to match new argument style