### PR TITLE
feat: add --json flag to all remaining commands

### DIFF
--- a/crates/unimorph-cli/src/commands/delete.rs
+++ b/crates/unimorph-cli/src/commands/delete.rs
@@ -8,19 +8,41 @@ use tracing::{info, instrument};
 use crate::util::{create_repo, validate_lang_code};
 
 #[instrument(skip_all, fields(lang))]
-pub fn cmd_delete(lang: &str, data_dir: Option<&Path>) -> Result<()> {
+pub fn cmd_delete(lang: &str, json: bool, data_dir: Option<&Path>) -> Result<()> {
     validate_lang_code(lang)?;
 
     let mut repo = create_repo(data_dir)?;
 
     if !repo.store().has_language(lang)? {
-        println!("Language '{}' is not cached.", lang);
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "lang": lang,
+                    "status": "not_found",
+                    "message": "Language is not cached."
+                })
+            );
+        } else {
+            println!("Language '{}' is not cached.", lang);
+        }
         return Ok(());
     }
 
     repo.delete(lang)?;
     info!(lang, "deleted language");
-    println!("Deleted {}.", lang);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "lang": lang,
+                "status": "deleted"
+            })
+        );
+    } else {
+        println!("Deleted {}.", lang);
+    }
 
     Ok(())
 }

--- a/crates/unimorph-cli/src/commands/download.rs
+++ b/crates/unimorph-cli/src/commands/download.rs
@@ -15,6 +15,7 @@ use crate::util::{create_repo, validate_lang_code};
 pub async fn cmd_download(
     lang: &str,
     force: bool,
+    json: bool,
     quiet: bool,
     data_dir: Option<&Path>,
 ) -> Result<()> {
@@ -26,7 +27,16 @@ pub async fn cmd_download(
 
     // Check if already cached (for non-force downloads)
     if !force && repo.store().has_language(lang)? {
-        if !quiet {
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "lang": lang,
+                    "status": "cached",
+                    "message": "Already cached. Use --force to re-download."
+                })
+            );
+        } else if !quiet {
             println!("{} is already cached. Use --force to re-download.", lang);
         }
         return Ok(());
@@ -104,18 +114,13 @@ pub async fn cmd_download(
         pb.finish_and_clear();
     }
 
-    // Show download summary
-    if !quiet
-        && let Ok(total) = total_downloaded.lock()
-        && *total > 0
-    {
-        println!("Downloaded {}", HumanBytes(*total));
-    }
+    let bytes_downloaded = total_downloaded.lock().map(|t| *t).unwrap_or(0);
 
     let stats = repo
         .store()
         .stats(lang)?
         .context("Failed to retrieve stats after download")?;
+
     info!(
         lang,
         entries = stats.total_entries,
@@ -123,7 +128,23 @@ pub async fn cmd_download(
         forms = stats.unique_forms,
         "download complete"
     );
-    if !quiet {
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "lang": lang,
+                "status": "downloaded",
+                "bytes": bytes_downloaded,
+                "entries": stats.total_entries,
+                "lemmas": stats.unique_lemmas,
+                "forms": stats.unique_forms
+            })
+        );
+    } else if !quiet {
+        if bytes_downloaded > 0 {
+            println!("Downloaded {}", HumanBytes(bytes_downloaded));
+        }
         println!(
             "{}: {} entries, {} lemmas, {} forms",
             lang, stats.total_entries, stats.unique_lemmas, stats.unique_forms

--- a/crates/unimorph-cli/src/commands/repair.rs
+++ b/crates/unimorph-cli/src/commands/repair.rs
@@ -13,7 +13,12 @@ fn available_languages_cache_path() -> Option<std::path::PathBuf> {
 }
 
 #[instrument(skip_all)]
-pub fn cmd_repair(clear_cache: bool, clear_data: bool, data_dir: Option<&Path>) -> Result<()> {
+pub fn cmd_repair(
+    clear_cache: bool,
+    clear_data: bool,
+    json: bool,
+    data_dir: Option<&Path>,
+) -> Result<()> {
     let mut actions_taken = Vec::new();
 
     // Clear cache files
@@ -85,7 +90,15 @@ pub fn cmd_repair(clear_cache: bool, clear_data: bool, data_dir: Option<&Path>) 
     }
 
     // Print summary
-    if actions_taken.is_empty() {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": if actions_taken.is_empty() { "no_action" } else { "complete" },
+                "actions": actions_taken
+            })
+        );
+    } else if actions_taken.is_empty() {
         println!("Nothing to do. Use --clear-cache or --clear-data to clear data.");
         println!();
         println!("Options:");

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
         /// Force re-download even if cached
         #[arg(short, long)]
         force: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// List languages
@@ -118,6 +122,10 @@ enum Commands {
     Delete {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
         lang: String,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Search entries with flexible filtering
@@ -219,6 +227,10 @@ enum Commands {
         /// Clear all downloaded datasets (will need to re-download)
         #[arg(long)]
         clear_data: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Explore morphological features in a language
@@ -284,8 +296,8 @@ async fn main() -> Result<()> {
     );
 
     match cli.command {
-        Commands::Download { lang, force } => {
-            cmd_download(&lang, force, cli.quiet, cli.data_dir.as_deref()).await
+        Commands::Download { lang, force, json } => {
+            cmd_download(&lang, force, json, cli.quiet, cli.data_dir.as_deref()).await
         }
         Commands::List {
             cached,
@@ -309,7 +321,7 @@ async fn main() -> Result<()> {
             cmd_analyze(&lang, &form, json, cli.data_dir.as_deref())
         }
         Commands::Stats { lang, json } => cmd_stats(&lang, json, cli.data_dir.as_deref()),
-        Commands::Delete { lang } => cmd_delete(&lang, cli.data_dir.as_deref()),
+        Commands::Delete { lang, json } => cmd_delete(&lang, json, cli.data_dir.as_deref()),
         Commands::Search {
             lang,
             lemma,
@@ -352,7 +364,8 @@ async fn main() -> Result<()> {
         Commands::Repair {
             clear_cache,
             clear_data,
-        } => cmd_repair(clear_cache, clear_data, cli.data_dir.as_deref()),
+            json,
+        } => cmd_repair(clear_cache, clear_data, json, cli.data_dir.as_deref()),
         Commands::Features {
             lang,
             list,


### PR DESCRIPTION
## Summary

Adds `--json` flag to the commands that were missing it for consistent scripting support.

### Commands Updated

| Command | JSON Output |
|---------|-------------|
| `download` | `{lang, status, bytes, entries, lemmas, forms}` |
| `delete` | `{lang, status}` |
| `repair` | `{status, actions[]}` |

### Examples

```bash
$ unimorph download heb --json
{"lang":"heb","status":"downloaded","bytes":1234567,"entries":45678,"lemmas":12345,"forms":34567}

$ unimorph delete heb --json
{"lang":"heb","status":"deleted"}

$ unimorph repair --json
{"status":"complete","actions":["Database OK (2 language(s) cached)"]}
```

All commands now support `--json` for scripting (except `export` and `completions` which have different output semantics).