### PR TITLE
feat: add color output for better readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,6 +4747,7 @@ dependencies = [
  "dirs",
  "indicatif",
  "octocrab",
+ "owo-colors",
  "predicates",
  "serde",
  "serde_json",

--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -31,6 +31,7 @@ color-eyre.workspace = true
 octocrab.workspace = true
 dirs.workspace = true
 chrono = "0.4"
+owo-colors = "4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/unimorph-cli/src/colors.rs
+++ b/crates/unimorph-cli/src/colors.rs
@@ -1,0 +1,84 @@
+//! Color output utilities.
+//!
+//! Respects NO_COLOR environment variable and terminal detection.
+
+use std::io::IsTerminal;
+
+use owo_colors::{OwoColorize, Style};
+
+/// Check if color output should be enabled.
+///
+/// Colors are disabled if:
+/// - NO_COLOR environment variable is set (any value)
+/// - stdout is not a terminal (piped output)
+pub fn should_colorize() -> bool {
+    std::env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal()
+}
+
+/// Style for language codes (e.g., "heb", "ita")
+pub fn lang_style() -> Style {
+    Style::new().cyan().bold()
+}
+
+/// Style for lemmas (dictionary forms)
+pub fn lemma_style() -> Style {
+    Style::new().green()
+}
+
+/// Style for surface forms
+pub fn form_style() -> Style {
+    Style::new().yellow()
+}
+
+/// Style for feature values
+pub fn feature_style() -> Style {
+    Style::new().magenta()
+}
+
+/// Style for numbers/counts
+pub fn number_style() -> Style {
+    Style::new().blue().bold()
+}
+
+/// Style for success messages
+pub fn success_style() -> Style {
+    Style::new().green().bold()
+}
+
+/// Style for warning messages
+pub fn warning_style() -> Style {
+    Style::new().yellow().bold()
+}
+
+/// Style for error messages
+#[allow(dead_code)]
+pub fn error_style() -> Style {
+    Style::new().red().bold()
+}
+
+/// Style for dimmed/secondary text
+pub fn dim_style() -> Style {
+    Style::new().dimmed()
+}
+
+/// Style for headers/titles
+pub fn header_style() -> Style {
+    Style::new().bold()
+}
+
+/// Conditionally apply style based on whether colors are enabled.
+pub fn styled<T: std::fmt::Display>(value: T, style: Style, colorize: bool) -> String {
+    if colorize {
+        value.style(style).to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Helper macro for styled output that respects color settings.
+#[macro_export]
+macro_rules! colorize {
+    ($value:expr, $style:expr, $enabled:expr) => {
+        $crate::colors::styled($value, $style, $enabled)
+    };
+}

--- a/crates/unimorph-cli/src/commands/analyze.rs
+++ b/crates/unimorph-cli/src/commands/analyze.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 use color_eyre::eyre::Result;
 use tracing::{debug, instrument};
 
+use crate::colors::{
+    dim_style, feature_style, form_style, header_style, lemma_style, number_style, should_colorize,
+    styled,
+};
 use crate::util::{create_repo, require_language, validate_lang_code};
 
 #[instrument(skip_all, fields(lang, form))]
@@ -31,13 +35,27 @@ pub fn cmd_analyze(lang: &str, form: &str, json: bool, data_dir: Option<&Path>) 
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
     } else {
-        println!("{:<20} {:<20} FEATURES", "FORM", "LEMMA");
-        println!("{}", "-".repeat(60));
+        let color = should_colorize();
+        println!(
+            "{:<20} {:<20} {}",
+            styled("FORM", header_style(), color),
+            styled("LEMMA", header_style(), color),
+            styled("FEATURES", header_style(), color)
+        );
+        println!("{}", styled("-".repeat(60), dim_style(), color));
         for entry in &entries {
-            println!("{:<20} {:<20} {}", entry.form, entry.lemma, entry.features);
+            println!(
+                "{:<20} {:<20} {}",
+                styled(&entry.form, form_style(), color),
+                styled(&entry.lemma, lemma_style(), color),
+                styled(&entry.features, feature_style(), color)
+            );
         }
         println!();
-        println!("{} analysis(es) found.", entries.len());
+        println!(
+            "{} analysis(es) found.",
+            styled(entries.len(), number_style(), color)
+        );
     }
 
     Ok(())

--- a/crates/unimorph-cli/src/commands/inflect.rs
+++ b/crates/unimorph-cli/src/commands/inflect.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 use color_eyre::eyre::Result;
 use tracing::{debug, instrument};
 
+use crate::colors::{
+    dim_style, feature_style, form_style, header_style, lemma_style, number_style, should_colorize,
+    styled,
+};
 use crate::util::{create_repo, require_language, validate_lang_code};
 
 #[instrument(skip_all, fields(lang, lemma))]
@@ -56,13 +60,27 @@ pub fn cmd_inflect(
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
     } else {
-        println!("{:<20} {:<20} FEATURES", "LEMMA", "FORM");
-        println!("{}", "-".repeat(60));
+        let color = should_colorize();
+        println!(
+            "{:<20} {:<20} {}",
+            styled("LEMMA", header_style(), color),
+            styled("FORM", header_style(), color),
+            styled("FEATURES", header_style(), color)
+        );
+        println!("{}", styled("-".repeat(60), dim_style(), color));
         for entry in &entries {
-            println!("{:<20} {:<20} {}", entry.lemma, entry.form, entry.features);
+            println!(
+                "{:<20} {:<20} {}",
+                styled(&entry.lemma, lemma_style(), color),
+                styled(&entry.form, form_style(), color),
+                styled(&entry.features, feature_style(), color)
+            );
         }
         println!();
-        println!("{} form(s) found.", entries.len());
+        println!(
+            "{} form(s) found.",
+            styled(entries.len(), number_style(), color)
+        );
     }
 
     Ok(())

--- a/crates/unimorph-cli/src/commands/info.rs
+++ b/crates/unimorph-cli/src/commands/info.rs
@@ -7,6 +7,10 @@ use color_eyre::eyre::{Context, ContextCompat, Result};
 use serde::Serialize;
 use tracing::{debug, instrument};
 
+use crate::colors::{
+    dim_style, header_style, lang_style, number_style, should_colorize, styled, success_style,
+    warning_style,
+};
 use crate::util::{create_repo, require_language, validate_lang_code};
 
 /// Format a Unix timestamp string as a human-readable date.
@@ -117,8 +121,17 @@ pub async fn cmd_info(lang: &str, json: bool, data_dir: Option<&Path>) -> Result
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        println!("Language: {}", lang);
-        println!("Source: {}", source);
+        let color = should_colorize();
+        println!(
+            "{} {}",
+            styled("Language:", header_style(), color),
+            styled(lang, lang_style(), color)
+        );
+        println!(
+            "{} {}",
+            styled("Source:", header_style(), color),
+            styled(&source, dim_style(), color)
+        );
         println!();
 
         if let Some(ref local) = imported_at {
@@ -136,19 +149,39 @@ pub async fn cmd_info(lang: &str, json: bool, data_dir: Option<&Path>) -> Result
 
         println!();
         if update_available {
-            println!("Status: UPDATE AVAILABLE");
+            println!(
+                "{} {}",
+                styled("Status:", header_style(), color),
+                styled("UPDATE AVAILABLE", warning_style(), color)
+            );
             println!();
             println!("Run 'unimorph update {}' to update.", lang);
         } else {
-            println!("Status: Up to date");
+            println!(
+                "{} {}",
+                styled("Status:", header_style(), color),
+                styled("Up to date", success_style(), color)
+            );
         }
 
         println!();
-        println!("Statistics:");
-        println!("  Total entries:   {}", stats.total_entries);
-        println!("  Unique lemmas:   {}", stats.unique_lemmas);
-        println!("  Unique forms:    {}", stats.unique_forms);
-        println!("  Unique features: {}", stats.unique_features);
+        println!("{}", styled("Statistics:", header_style(), color));
+        println!(
+            "  Total entries:   {}",
+            styled(stats.total_entries, number_style(), color)
+        );
+        println!(
+            "  Unique lemmas:   {}",
+            styled(stats.unique_lemmas, number_style(), color)
+        );
+        println!(
+            "  Unique forms:    {}",
+            styled(stats.unique_forms, number_style(), color)
+        );
+        println!(
+            "  Unique features: {}",
+            styled(stats.unique_features, number_style(), color)
+        );
     }
 
     Ok(())

--- a/crates/unimorph-cli/src/commands/search.rs
+++ b/crates/unimorph-cli/src/commands/search.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 use color_eyre::eyre::Result;
 use tracing::{debug, instrument};
 
+use crate::colors::{
+    dim_style, feature_style, form_style, header_style, lemma_style, number_style, should_colorize,
+    styled,
+};
 use crate::util::{create_repo, require_language, validate_lang_code};
 
 #[instrument(skip_all, fields(lang))]
@@ -67,13 +71,27 @@ pub fn cmd_search(
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
     } else {
-        println!("{:<20} {:<20} FEATURES", "LEMMA", "FORM");
-        println!("{}", "-".repeat(60));
+        let color = should_colorize();
+        println!(
+            "{:<20} {:<20} {}",
+            styled("LEMMA", header_style(), color),
+            styled("FORM", header_style(), color),
+            styled("FEATURES", header_style(), color)
+        );
+        println!("{}", styled("-".repeat(60), dim_style(), color));
         for entry in &entries {
-            println!("{:<20} {:<20} {}", entry.lemma, entry.form, entry.features);
+            println!(
+                "{:<20} {:<20} {}",
+                styled(&entry.lemma, lemma_style(), color),
+                styled(&entry.form, form_style(), color),
+                styled(&entry.features, feature_style(), color)
+            );
         }
         println!();
-        println!("{} result(s).", entries.len());
+        println!(
+            "{} result(s).",
+            styled(entries.len(), number_style(), color)
+        );
     }
 
     Ok(())

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -1,5 +1,6 @@
 //! UniMorph CLI - Command-line interface for UniMorph morphological data.
 
+mod colors;
 mod commands;
 mod util;
 


### PR DESCRIPTION
## Summary

Adds colorized output to improve readability of CLI results.

### Features

- New `colors` module with consistent style definitions
- Colorized output for `inflect`, `analyze`, `search`, and `info` commands
- Respects `NO_COLOR` environment variable
- Automatically disables colors when stdout is piped (not a terminal)

### Color Scheme

| Element | Color |
|---------|-------|
| Language codes | Cyan, bold |
| Lemmas | Green |
| Surface forms | Yellow |
| Feature values | Magenta |
| Numbers/counts | Blue, bold |
| Success status | Green, bold |
| Warning status | Yellow, bold |

### Examples

```bash
# Colors enabled in terminal
unimorph inflect heb word

# Colors disabled when piped
unimorph inflect heb word | cat

# Force disable colors
NO_COLOR=1 unimorph inflect heb word
```

Closes #32