### PR TITLE
feat: add --contains filter to search command

### DIFF
--- a/crates/unimorph-cli/src/commands/search.rs
+++ b/crates/unimorph-cli/src/commands/search.rs
@@ -18,6 +18,7 @@ pub fn cmd_search(
     lemma: Option<&str>,
     form: Option<&str>,
     features: Option<&str>,
+    contains: Option<Vec<String>>,
     pos: Option<&str>,
     limit: usize,
     offset: Option<usize>,
@@ -40,6 +41,10 @@ pub fn cmd_search(
     }
     if let Some(feat) = features {
         query = query.features_match(feat);
+    }
+    if let Some(ref c) = contains {
+        let refs: Vec<&str> = c.iter().map(|s| s.as_str()).collect();
+        query = query.features_contain(&refs);
     }
     if let Some(p) = pos {
         query = query.pos(p);

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -147,6 +147,11 @@ enum Commands {
         #[arg(short, long)]
         features: Option<String>,
 
+        /// Filter by features contained (comma-separated, position-independent)
+        /// Example: --contains PL,MASC finds entries with both PL and MASC
+        #[arg(short, long, value_delimiter = ',')]
+        contains: Option<Vec<String>>,
+
         /// Filter by part of speech (e.g., V, N, ADJ)
         #[arg(long)]
         pos: Option<String>,
@@ -328,6 +333,7 @@ async fn main() -> Result<()> {
             lemma,
             form,
             features,
+            contains,
             pos,
             limit,
             offset,
@@ -338,6 +344,7 @@ async fn main() -> Result<()> {
             lemma.as_deref(),
             form.as_deref(),
             features.as_deref(),
+            contains,
             pos.as_deref(),
             limit,
             offset,

--- a/crates/unimorph-core/src/query.rs
+++ b/crates/unimorph-core/src/query.rs
@@ -226,15 +226,22 @@ impl<'a> QueryBuilder<'a> {
             params_vec.push(Box::new(sql_pattern));
         }
 
-        // Add LIMIT and OFFSET (OFFSET requires LIMIT in SQLite)
-        if let Some(limit) = self.limit {
-            sql.push_str(&format!(" LIMIT {}", limit));
-            if let Some(offset) = self.offset {
-                sql.push_str(&format!(" OFFSET {}", offset));
+        // Check if we have post-filters that need to run after SQL
+        let has_post_filters = !self.features_contain.is_empty()
+            || self.pos.is_some()
+            || self.features_pattern.is_some();
+
+        // Only apply SQL LIMIT/OFFSET if no post-filters (otherwise we filter after fetch)
+        if !has_post_filters {
+            if let Some(limit) = self.limit {
+                sql.push_str(&format!(" LIMIT {}", limit));
+                if let Some(offset) = self.offset {
+                    sql.push_str(&format!(" OFFSET {}", offset));
+                }
+            } else if self.offset.is_some() {
+                // OFFSET without LIMIT: use a very large limit
+                sql.push_str(&format!(" LIMIT -1 OFFSET {}", self.offset.unwrap()));
             }
-        } else if self.offset.is_some() {
-            // OFFSET without LIMIT: use a very large limit
-            sql.push_str(&format!(" LIMIT -1 OFFSET {}", self.offset.unwrap()));
         }
 
         // Execute query
@@ -242,7 +249,7 @@ impl<'a> QueryBuilder<'a> {
         let params_refs: Vec<&dyn rusqlite::ToSql> =
             params_vec.iter().map(|b| b.as_ref()).collect();
 
-        let entries: Vec<Entry> = stmt
+        let iter = stmt
             .query_map(params_refs.as_slice(), |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -279,8 +286,19 @@ impl<'a> QueryBuilder<'a> {
                     return false;
                 }
                 true
-            })
-            .collect();
+            });
+
+        // Apply limit/offset after post-filters when post-filters are present
+        let entries: Vec<Entry> = if has_post_filters {
+            match (self.offset, self.limit) {
+                (Some(offset), Some(limit)) => iter.skip(offset).take(limit).collect(),
+                (Some(offset), None) => iter.skip(offset).collect(),
+                (None, Some(limit)) => iter.take(limit).collect(),
+                (None, None) => iter.collect(),
+            }
+        } else {
+            iter.collect()
+        };
 
         debug!(count = entries.len(), "query returned entries");
         Ok(entries)


### PR DESCRIPTION
Add position-independent feature filtering with `--contains` flag. Accepts comma-separated features and finds entries containing all specified features regardless of position.

## Example

```bash
# Find all entries with FEM and SG features (in any position)
unimorph search heb --contains FEM,SG

# Combine with other filters
unimorph search heb --lemma 'אבד' --contains FEM
```

## Changes

- Add `-c, --contains` option to search command
- Fix query builder to apply LIMIT/OFFSET after post-filters instead of at SQL level
  - Previously, `features_contain`, `pos`, and `features_match` filters could return fewer results than expected because LIMIT was applied before filtering

Closes #38