### PR TITLE
feat: add default language configuration

### DIFF
--- a/crates/unimorph-cli/src/config.rs
+++ b/crates/unimorph-cli/src/config.rs
@@ -118,6 +118,43 @@ impl Config {
         }
         lang_or_alias.to_string()
     }
+
+    /// Get the default language from environment variable or config file.
+    ///
+    /// Priority order:
+    /// 1. UNIMORPH_LANG environment variable
+    /// 2. Config file default_lang
+    ///
+    /// Returns None if no default is set.
+    pub fn default_lang(&self) -> Option<String> {
+        // Check environment variable first
+        if let Ok(lang) = std::env::var("UNIMORPH_LANG")
+            && !lang.is_empty()
+        {
+            debug!(lang = %lang, "Using default language from UNIMORPH_LANG");
+            return Some(self.resolve_lang(&lang));
+        }
+
+        // Fall back to config file
+        if let Some(lang) = &self.default_lang {
+            debug!(lang = %lang, "Using default language from config file");
+            return Some(self.resolve_lang(lang));
+        }
+
+        None
+    }
+
+    /// Resolve the effective language: use provided value or fall back to default.
+    ///
+    /// If `lang` is Some, resolves any aliases and returns it.
+    /// If `lang` is None, returns the default language (env > config).
+    /// Returns None if no language is provided and no default is set.
+    pub fn effective_lang(&self, lang: Option<&str>) -> Option<String> {
+        match lang {
+            Some(l) => Some(self.resolve_lang(l)),
+            None => self.default_lang(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -188,5 +225,31 @@ mod tests {
     fn test_load_nonexistent_file() {
         let config = Config::load_from(Path::new("/nonexistent/path/config.toml"));
         assert!(config.default_lang.is_none());
+    }
+
+    #[test]
+    fn test_effective_lang_with_explicit() {
+        let toml = r#"
+            default_lang = "ita"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        // Explicit lang should always be used regardless of default
+        assert_eq!(config.effective_lang(Some("heb")), Some("heb".to_string()));
+    }
+
+    #[test]
+    fn test_effective_lang_resolves_alias() {
+        let toml = r#"
+            [languages.heb]
+            alias = "hebrew"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        // Alias should be resolved
+        assert_eq!(
+            config.effective_lang(Some("hebrew")),
+            Some("heb".to_string())
+        );
     }
 }

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -14,12 +14,25 @@ use color_eyre::eyre::Result;
 use tracing::debug;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+use color_eyre::eyre::eyre;
 use commands::{
     ExportFormat, cmd_analyze, cmd_config_init, cmd_config_path, cmd_config_show, cmd_delete,
     cmd_download, cmd_export, cmd_features, cmd_inflect, cmd_info, cmd_list, cmd_repair,
     cmd_search, cmd_stats, cmd_update,
 };
 use config::Config;
+
+/// Error message when no language is specified and no default is configured.
+fn no_language_error() -> color_eyre::eyre::Report {
+    eyre!(
+        "No language specified.\n\n\
+        Provide a language code as an argument, or set a default:\n\n\
+        \x20 export UNIMORPH_LANG=heb\n\n\
+        Or in ~/.config/unimorph/config.toml:\n\n\
+        \x20 default_lang = \"heb\"\n\n\
+        Run 'unimorph list --available' to see available languages."
+    )
+}
 
 #[derive(Parser)]
 #[command(name = "unimorph")]
@@ -47,7 +60,8 @@ enum Commands {
     #[command(visible_alias = "dl")]
     Download {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        lang: Option<String>,
 
         /// Force re-download even if cached
         #[arg(short, long)]
@@ -81,11 +95,13 @@ enum Commands {
     /// Look up all forms of a lemma (dictionary form)
     #[command(visible_alias = "i")]
     Inflect {
-        /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
-
         /// Lemma to look up
         lemma: String,
+
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        #[arg(short, long)]
+        lang: Option<String>,
 
         /// Filter by feature pattern (e.g., "V;IND;*;SG")
         #[arg(short, long)]
@@ -99,11 +115,13 @@ enum Commands {
     /// Analyze a surface form (reverse lookup)
     #[command(visible_alias = "a")]
     Analyze {
-        /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
-
         /// Form to analyze
         form: String,
+
+        /// Language code (ISO 639-3, e.g., heb, vec, deu)
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        #[arg(short, long)]
+        lang: Option<String>,
 
         /// Output as JSON
         #[arg(long)]
@@ -114,7 +132,8 @@ enum Commands {
     #[command(visible_alias = "st")]
     Stats {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        lang: Option<String>,
 
         /// Output as JSON
         #[arg(long)]
@@ -125,7 +144,8 @@ enum Commands {
     #[command(visible_alias = "rm")]
     Delete {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        lang: Option<String>,
 
         /// Output as JSON
         #[arg(long)]
@@ -136,7 +156,9 @@ enum Commands {
     #[command(visible_alias = "s")]
     Search {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        #[arg(short, long)]
+        lang: Option<String>,
 
         /// Filter by lemma (supports SQL LIKE wildcards: % and _)
         #[arg(long)]
@@ -180,14 +202,16 @@ enum Commands {
     #[command(visible_alias = "x")]
     Export {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        #[arg(short, long)]
+        lang: Option<String>,
 
         /// Output file path (use - for stdout)
         #[arg(short, long)]
         output: Option<PathBuf>,
 
         /// Output format (auto-detected from extension if not specified)
-        #[arg(short, long)]
+        #[arg(short = 'F', long)]
         format: Option<ExportFormat>,
     },
 
@@ -201,7 +225,8 @@ enum Commands {
     #[command(visible_alias = "in")]
     Info {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        lang: Option<String>,
 
         /// Output as JSON
         #[arg(long)]
@@ -246,7 +271,9 @@ enum Commands {
     #[command(visible_alias = "f")]
     Features {
         /// Language code (ISO 639-3, e.g., heb, vec, deu)
-        lang: String,
+        /// Uses UNIMORPH_LANG env var or config default if not specified
+        #[arg(short, long)]
+        lang: Option<String>,
 
         /// List all unique feature values
         #[arg(long)]
@@ -364,7 +391,9 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Download { lang, force, json } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_download(&lang, force, json, cli.quiet, data_dir.as_deref()).await
         }
         Commands::List {
@@ -374,12 +403,14 @@ async fn main() -> Result<()> {
             json,
         } => cmd_list(cached, available, refresh, json, data_dir.as_deref()).await,
         Commands::Inflect {
-            lang,
             lemma,
+            lang,
             features,
             json,
         } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_inflect(
                 &lang,
                 &lemma,
@@ -388,16 +419,22 @@ async fn main() -> Result<()> {
                 data_dir.as_deref(),
             )
         }
-        Commands::Analyze { lang, form, json } => {
-            let lang = config.resolve_lang(&lang);
+        Commands::Analyze { form, lang, json } => {
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_analyze(&lang, &form, json, data_dir.as_deref())
         }
         Commands::Stats { lang, json } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_stats(&lang, json, data_dir.as_deref())
         }
         Commands::Delete { lang, json } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_delete(&lang, json, data_dir.as_deref())
         }
         Commands::Search {
@@ -412,7 +449,9 @@ async fn main() -> Result<()> {
             count,
             json,
         } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_search(
                 &lang,
                 lemma.as_deref(),
@@ -432,7 +471,9 @@ async fn main() -> Result<()> {
             output,
             format,
         } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_export(&lang, output, format, data_dir.as_deref())
         }
         Commands::Completions { shell } => {
@@ -441,7 +482,9 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Info { lang, json } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_info(&lang, json, data_dir.as_deref()).await
         }
         Commands::Update {
@@ -450,7 +493,16 @@ async fn main() -> Result<()> {
             check,
             json,
         } => {
-            let lang = lang.map(|l| config.resolve_lang(&l));
+            // Update command: lang is optional if --all is used
+            let lang = if all {
+                None
+            } else {
+                Some(
+                    config
+                        .effective_lang(lang.as_deref())
+                        .ok_or_else(no_language_error)?,
+                )
+            };
             cmd_update(lang.as_deref(), all, check, json, data_dir.as_deref()).await
         }
         Commands::Repair {
@@ -467,7 +519,9 @@ async fn main() -> Result<()> {
             limit,
             json,
         } => {
-            let lang = config.resolve_lang(&lang);
+            let lang = config
+                .effective_lang(lang.as_deref())
+                .ok_or_else(no_language_error)?;
             cmd_features(
                 &lang,
                 list,

--- a/crates/unimorph-cli/tests/cli.rs
+++ b/crates/unimorph-cli/tests/cli.rs
@@ -53,7 +53,7 @@ mod help {
             .args(["download", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("<LANG>"))
+            .stdout(predicate::str::contains("[LANG]"))
             .stdout(predicate::str::contains("--force"));
     }
 
@@ -63,7 +63,7 @@ mod help {
             .args(["inflect", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("<LANG>"))
+            .stdout(predicate::str::contains("--lang"))
             .stdout(predicate::str::contains("<LEMMA>"))
             .stdout(predicate::str::contains("--features"))
             .stdout(predicate::str::contains("--json"));
@@ -75,7 +75,7 @@ mod help {
             .args(["analyze", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("<LANG>"))
+            .stdout(predicate::str::contains("--lang"))
             .stdout(predicate::str::contains("<FORM>"))
             .stdout(predicate::str::contains("--json"));
     }
@@ -86,7 +86,7 @@ mod help {
             .args(["stats", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("<LANG>"))
+            .stdout(predicate::str::contains("[LANG]"))
             .stdout(predicate::str::contains("--json"));
     }
 
@@ -105,7 +105,7 @@ mod help {
             .args(["delete", "--help"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("<LANG>"));
+            .stdout(predicate::str::contains("[LANG]"));
     }
 }
 
@@ -130,58 +130,67 @@ mod errors {
     }
 
     #[test]
-    fn download_requires_lang() {
+    fn download_without_lang_shows_helpful_error() {
+        // Without a default language set, should show helpful error
         unimorph()
             .arg("download")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("<LANG>"));
-    }
-
-    #[test]
-    fn inflect_requires_lang() {
-        unimorph()
-            .arg("inflect")
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains("<LANG>"));
+            .stderr(predicate::str::contains("No language specified"));
     }
 
     #[test]
     fn inflect_requires_lemma() {
-        unimorph().args(["inflect", "ita"]).assert().failure();
+        unimorph()
+            .arg("inflect")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("<LEMMA>"));
     }
 
     #[test]
-    fn analyze_requires_lang() {
+    fn inflect_with_lemma_but_no_lang_shows_helpful_error() {
         unimorph()
-            .arg("analyze")
+            .args(["inflect", "parlare"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("<LANG>"));
+            .stderr(predicate::str::contains("No language specified"));
     }
 
     #[test]
     fn analyze_requires_form() {
-        unimorph().args(["analyze", "ita"]).assert().failure();
+        unimorph()
+            .arg("analyze")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("<FORM>"));
     }
 
     #[test]
-    fn stats_requires_lang() {
+    fn analyze_with_form_but_no_lang_shows_helpful_error() {
+        unimorph()
+            .args(["analyze", "parlo"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("No language specified"));
+    }
+
+    #[test]
+    fn stats_without_lang_shows_helpful_error() {
         unimorph()
             .arg("stats")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("<LANG>"));
+            .stderr(predicate::str::contains("No language specified"));
     }
 
     #[test]
-    fn delete_requires_lang() {
+    fn delete_without_lang_shows_helpful_error() {
         unimorph()
             .arg("delete")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("<LANG>"));
+            .stderr(predicate::str::contains("No language specified"));
     }
 }
 


### PR DESCRIPTION
## Summary

Add support for setting a default language to avoid typing it repeatedly.

## Changes

- Add `UNIMORPH_LANG` environment variable support
- Make `lang` argument optional in all commands that accept it
- Fall back to env var, then config file `default_lang`
- Show helpful error message when no language is available

## Priority Order

1. CLI argument (explicit `-l`/`--lang` or positional)
2. `UNIMORPH_LANG` environment variable
3. `default_lang` in config file
4. Error with helpful message

## Usage

```bash
# Set via environment variable
export UNIMORPH_LANG=heb
unimorph inflect lemma  # Uses heb

# Or in ~/.config/unimorph/config.toml
default_lang = "heb"

# Explicit argument always overrides
unimorph inflect -l ita parlare  # Uses ita
```

## Commands Affected

- download
- inflect
- analyze
- stats
- delete
- search
- export
- info
- update
- features

## Testing

All 112 tests pass.

Closes #36