### PR TITLE
feat: add pipe-friendly output modes

### DIFF
--- a/crates/unimorph-cli/src/commands/analyze.rs
+++ b/crates/unimorph-cli/src/commands/analyze.rs
@@ -12,7 +12,13 @@ use crate::colors::{
 use crate::util::{create_repo, require_language, validate_lang_code};
 
 #[instrument(skip_all, fields(lang, form))]
-pub fn cmd_analyze(lang: &str, form: &str, json: bool, data_dir: Option<&Path>) -> Result<()> {
+pub fn cmd_analyze(
+    lang: &str,
+    form: &str,
+    json: bool,
+    tsv: bool,
+    data_dir: Option<&Path>,
+) -> Result<()> {
     validate_lang_code(lang)?;
 
     let repo = create_repo(data_dir)?;
@@ -34,6 +40,11 @@ pub fn cmd_analyze(lang: &str, form: &str, json: bool, data_dir: Option<&Path>) 
 
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
+    } else if tsv {
+        // TSV output: tab-separated, no headers, no summary - ideal for piping
+        for entry in &entries {
+            println!("{}\t{}\t{}", entry.form, entry.lemma, entry.features);
+        }
     } else {
         let color = should_colorize();
         println!(

--- a/crates/unimorph-cli/src/commands/features.rs
+++ b/crates/unimorph-cli/src/commands/features.rs
@@ -1,6 +1,7 @@
 //! Features command implementation.
 
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::path::Path;
 
 use color_eyre::eyre::Result;
@@ -44,7 +45,7 @@ pub fn cmd_features(
 
         if json {
             println!("{}", serde_json::to_string_pretty(&all_features)?);
-        } else {
+        } else if std::io::stdout().is_terminal() {
             println!("Unique features in {}:", lang);
             println!();
             for feat in &all_features {
@@ -52,6 +53,11 @@ pub fn cmd_features(
             }
             println!();
             println!("{} unique feature values.", all_features.len());
+        } else {
+            // Pipe-friendly: one feature per line
+            for feat in &all_features {
+                println!("{}", feat);
+            }
         }
         return Ok(());
     }
@@ -71,7 +77,7 @@ pub fn cmd_features(
         if json {
             let map: HashMap<_, _> = sorted.into_iter().collect();
             println!("{}", serde_json::to_string_pretty(&map)?);
-        } else {
+        } else if std::io::stdout().is_terminal() {
             println!("Feature statistics for {}:", lang);
             println!();
             println!("{:<20} COUNT", "FEATURE");
@@ -81,6 +87,11 @@ pub fn cmd_features(
             }
             if sorted.len() > limit {
                 println!("... and {} more", sorted.len() - limit);
+            }
+        } else {
+            // Pipe-friendly: TSV output (feature\tcount)
+            for (feat, count) in sorted.iter().take(limit) {
+                println!("{}\t{}", feat, count);
             }
         }
         return Ok(());
@@ -102,7 +113,7 @@ pub fn cmd_features(
 
         if json {
             println!("{}", serde_json::to_string_pretty(&matching)?);
-        } else {
+        } else if std::io::stdout().is_terminal() {
             if matching.is_empty() {
                 println!("No entries with feature '{}' found.", term);
                 return Ok(());
@@ -119,6 +130,11 @@ pub fn cmd_features(
                 println!("Showing {} of {} results.", limit, total_count);
             } else {
                 println!("{} result(s).", matching.len());
+            }
+        } else {
+            // Pipe-friendly: TSV output (lemma\tform\tfeatures)
+            for entry in &matching {
+                println!("{}\t{}\t{}", entry.lemma, entry.form, entry.features);
             }
         }
         return Ok(());
@@ -139,7 +155,7 @@ pub fn cmd_features(
         if json {
             let map: HashMap<_, _> = sorted.into_iter().collect();
             println!("{}", serde_json::to_string_pretty(&map)?);
-        } else {
+        } else if std::io::stdout().is_terminal() {
             println!("Feature values at position {} in {}:", pos, lang);
             println!();
             println!("{:<20} COUNT", "VALUE");
@@ -149,6 +165,11 @@ pub fn cmd_features(
             }
             if sorted.len() > limit {
                 println!("... and {} more", sorted.len() - limit);
+            }
+        } else {
+            // Pipe-friendly: TSV output (value\tcount)
+            for (val, count) in sorted.iter().take(limit) {
+                println!("{}\t{}", val, count);
             }
         }
         return Ok(());
@@ -183,7 +204,7 @@ pub fn cmd_features(
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&summary)?);
-    } else {
+    } else if std::io::stdout().is_terminal() {
         println!("Feature structure for {}:", lang);
         println!();
         for (i, counts) in position_counts.iter().enumerate() {
@@ -201,6 +222,11 @@ pub fn cmd_features(
         println!(
             "Use --list for all unique values, --stats for counts, --search <FEATURE> to find entries."
         );
+    } else {
+        // Pipe-friendly: TSV output (position\tunique_count)
+        for (i, counts) in position_counts.iter().enumerate() {
+            println!("{}\t{}", i, counts.len());
+        }
     }
 
     Ok(())

--- a/crates/unimorph-cli/src/commands/inflect.rs
+++ b/crates/unimorph-cli/src/commands/inflect.rs
@@ -17,6 +17,7 @@ pub fn cmd_inflect(
     lemma: &str,
     features: Option<&str>,
     json: bool,
+    tsv: bool,
     data_dir: Option<&Path>,
 ) -> Result<()> {
     validate_lang_code(lang)?;
@@ -59,6 +60,11 @@ pub fn cmd_inflect(
 
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
+    } else if tsv {
+        // TSV output: tab-separated, no headers, no summary - ideal for piping
+        for entry in &entries {
+            println!("{}\t{}\t{}", entry.lemma, entry.form, entry.features);
+        }
     } else {
         let color = should_colorize();
         println!(

--- a/crates/unimorph-cli/src/commands/list.rs
+++ b/crates/unimorph-cli/src/commands/list.rs
@@ -1,6 +1,7 @@
 //! List command implementation.
 
 use std::collections::HashSet;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{Context, Result};
@@ -146,7 +147,7 @@ pub async fn cmd_list(
         if cached_langs.is_empty() {
             if json {
                 println!("[]");
-            } else {
+            } else if std::io::stdout().is_terminal() {
                 println!("No languages cached.");
                 println!();
                 println!("To download a language:");
@@ -156,10 +157,11 @@ pub async fn cmd_list(
                 println!("  unimorph download heb   # Hebrew");
                 println!("  unimorph download vec   # Venetian");
             }
+            // When piped with no languages, output nothing
         } else if json {
             let langs: Vec<_> = cached_langs.iter().collect();
             println!("{}", serde_json::to_string_pretty(&langs)?);
-        } else {
+        } else if std::io::stdout().is_terminal() {
             println!("Cached languages:");
             let mut langs: Vec<_> = cached_langs.iter().collect();
             langs.sort();
@@ -170,6 +172,13 @@ pub async fn cmd_list(
                 } else {
                     println!("  {}", lang);
                 }
+            }
+        } else {
+            // Pipe-friendly: just output language codes, one per line
+            let mut langs: Vec<_> = cached_langs.iter().collect();
+            langs.sort();
+            for lang in langs {
+                println!("{}", lang);
             }
         }
         return Ok(());
@@ -205,7 +214,7 @@ pub async fn cmd_list(
                 })
                 .collect();
             println!("{}", serde_json::to_string_pretty(&langs)?);
-        } else {
+        } else if std::io::stdout().is_terminal() {
             println!(
                 "Available languages ({} total, {} cached):",
                 available_langs.len(),
@@ -222,6 +231,11 @@ pub async fn cmd_list(
             println!();
             println!("Use 'unimorph download <code>' to download a language.");
             println!("Use 'unimorph list --refresh' to update this list.");
+        } else {
+            // Pipe-friendly: just output language codes, one per line
+            for lang in &available_langs {
+                println!("{}", lang);
+            }
         }
         return Ok(());
     }
@@ -231,7 +245,7 @@ pub async fn cmd_list(
         // No languages cached - show helpful info
         if json {
             println!("[]");
-        } else {
+        } else if std::io::stdout().is_terminal() {
             println!("No languages cached yet.");
             println!();
             println!("To download a language:");
@@ -246,10 +260,11 @@ pub async fn cmd_list(
             println!();
             println!("More info: https://github.com/unimorph");
         }
+        // When piped with no languages, output nothing
     } else if json {
         let langs: Vec<_> = cached_langs.iter().collect();
         println!("{}", serde_json::to_string_pretty(&langs)?);
-    } else {
+    } else if std::io::stdout().is_terminal() {
         println!("Cached languages:");
         let mut langs: Vec<_> = cached_langs.iter().collect();
         langs.sort();
@@ -263,6 +278,13 @@ pub async fn cmd_list(
         }
         println!();
         println!("Use 'unimorph list --available' to see all available languages.");
+    } else {
+        // Pipe-friendly: just output language codes, one per line
+        let mut langs: Vec<_> = cached_langs.iter().collect();
+        langs.sort();
+        for lang in langs {
+            println!("{}", lang);
+        }
     }
 
     Ok(())

--- a/crates/unimorph-cli/src/commands/search.rs
+++ b/crates/unimorph-cli/src/commands/search.rs
@@ -24,6 +24,7 @@ pub fn cmd_search(
     offset: Option<usize>,
     count: bool,
     json: bool,
+    tsv: bool,
     data_dir: Option<&Path>,
 ) -> Result<()> {
     validate_lang_code(lang)?;
@@ -75,6 +76,11 @@ pub fn cmd_search(
 
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
+    } else if tsv {
+        // TSV output: tab-separated, no headers, no summary - ideal for piping
+        for entry in &entries {
+            println!("{}\t{}\t{}", entry.lemma, entry.form, entry.features);
+        }
     } else {
         let color = should_colorize();
         println!(

--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -110,6 +110,10 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Output as TSV (tab-separated, no headers) for piping
+        #[arg(long)]
+        tsv: bool,
     },
 
     /// Analyze a surface form (reverse lookup)
@@ -126,6 +130,10 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Output as TSV (tab-separated, no headers) for piping
+        #[arg(long)]
+        tsv: bool,
     },
 
     /// Show dataset statistics
@@ -196,6 +204,10 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Output as TSV (tab-separated, no headers) for piping
+        #[arg(long)]
+        tsv: bool,
     },
 
     /// Export a language dataset to file
@@ -407,6 +419,7 @@ async fn main() -> Result<()> {
             lang,
             features,
             json,
+            tsv,
         } => {
             let lang = config
                 .effective_lang(lang.as_deref())
@@ -416,14 +429,20 @@ async fn main() -> Result<()> {
                 &lemma,
                 features.as_deref(),
                 json,
+                tsv,
                 data_dir.as_deref(),
             )
         }
-        Commands::Analyze { form, lang, json } => {
+        Commands::Analyze {
+            form,
+            lang,
+            json,
+            tsv,
+        } => {
             let lang = config
                 .effective_lang(lang.as_deref())
                 .ok_or_else(no_language_error)?;
-            cmd_analyze(&lang, &form, json, data_dir.as_deref())
+            cmd_analyze(&lang, &form, json, tsv, data_dir.as_deref())
         }
         Commands::Stats { lang, json } => {
             let lang = config
@@ -448,6 +467,7 @@ async fn main() -> Result<()> {
             offset,
             count,
             json,
+            tsv,
         } => {
             let lang = config
                 .effective_lang(lang.as_deref())
@@ -463,6 +483,7 @@ async fn main() -> Result<()> {
                 offset,
                 count,
                 json,
+                tsv,
                 data_dir.as_deref(),
             )
         }

--- a/crates/unimorph-cli/tests/cli.rs
+++ b/crates/unimorph-cli/tests/cli.rs
@@ -199,12 +199,9 @@ mod list_command {
 
     #[test]
     fn list_shows_cached_by_default() {
-        // Default behavior now shows cached languages or helpful info
-        unimorph()
-            .arg("list")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("list --available"));
+        // Default behavior shows cached languages (pipe-friendly when not TTY)
+        // or nothing if no languages are cached
+        unimorph().arg("list").assert().success();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds pipe-friendly output modes for better shell scripting and pipeline integration.

## Changes

### New `--tsv` flag for data commands
- **inflect**: `unimorph inflect parlare -l ita --tsv` outputs tab-separated data without headers
- **analyze**: `unimorph analyze parlo -l ita --tsv` outputs tab-separated data without headers  
- **search**: `unimorph search -l ita --lemma parlare --tsv` outputs tab-separated data without headers

### Automatic pipe-friendly output when not a TTY
- **list**: Outputs just language codes (one per line) when piped
- **features**: All modes output pipe-friendly format when piped:
  - `--list`: one feature per line
  - `--stats`: TSV (feature, count)
  - `--search`: TSV (lemma, form, features)
  - `--position`: TSV (value, count)
  - default: TSV (position, unique_count)

## Example Usage

```bash
# Get all forms of a verb and pipe to another command
unimorph inflect parlare -l ita --tsv | cut -f2 | sort -u

# List cached languages for scripting
unimorph list | xargs -I{} unimorph stats {}

# Search and process results
unimorph search -l ita --pos V --tsv | head -100 > verbs.tsv
```

## Testing
- All existing tests pass
- Updated test for list command to handle non-TTY behavior

Closes #35