### PR TITLE
fix: export -o - now correctly writes to stdout

### DIFF
--- a/crates/unimorph-cli/src/commands/export.rs
+++ b/crates/unimorph-cli/src/commands/export.rs
@@ -1,9 +1,10 @@
 //! Export command implementation.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use clap::ValueEnum;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use tracing::{info, instrument};
 
 use crate::util::{create_repo, require_language, validate_lang_code};
@@ -29,35 +30,63 @@ pub fn cmd_export(
     let repo = create_repo(data_dir)?;
     require_language(&repo, lang)?;
 
+    // Check if outputting to stdout
+    let is_stdout = output.as_ref().is_some_and(|p| p.as_os_str() == "-");
+
     // Determine format from flag or file extension
     let format = match (format, &output) {
         (Some(f), _) => f,
-        (None, Some(path)) => match path.extension().and_then(|e| e.to_str()) {
+        (None, Some(path)) if !is_stdout => match path.extension().and_then(|e| e.to_str()) {
             Some("tsv") => ExportFormat::Tsv,
             Some("jsonl") => ExportFormat::Jsonl,
             #[cfg(feature = "parquet")]
             Some("parquet") => ExportFormat::Parquet,
             _ => ExportFormat::Tsv, // default
         },
-        (None, None) => ExportFormat::Tsv,
+        _ => ExportFormat::Tsv,
     };
 
-    let output_path = output.unwrap_or_else(|| PathBuf::from(format!("{}.tsv", lang)));
-
-    let count = match format {
-        ExportFormat::Tsv => repo.store().export_tsv(lang, &output_path)?,
-        ExportFormat::Jsonl => repo.store().export_jsonl(lang, &output_path)?,
+    if is_stdout {
+        // Export to stdout
         #[cfg(feature = "parquet")]
-        ExportFormat::Parquet => repo.store().export_parquet(lang, &output_path)?,
-    };
+        if matches!(format, ExportFormat::Parquet) {
+            return Err(eyre!("Cannot export Parquet format to stdout"));
+        }
 
-    info!(
-        lang,
-        path = %output_path.display(),
-        count,
-        "export complete"
-    );
-    println!("Exported {} entries to {}", count, output_path.display());
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+
+        let count = match format {
+            ExportFormat::Tsv => repo.store().export_tsv_to_writer(lang, &mut handle)?,
+            ExportFormat::Jsonl => repo.store().export_jsonl_to_writer(lang, &mut handle)?,
+            #[cfg(feature = "parquet")]
+            ExportFormat::Parquet => unreachable!(),
+        };
+
+        handle.flush()?;
+
+        // Print message to stderr so it doesn't pollute the data stream
+        eprintln!("Exported {} entries to stdout", count);
+        info!(lang, count, "export to stdout complete");
+    } else {
+        // Export to file
+        let output_path = output.unwrap_or_else(|| PathBuf::from(format!("{}.tsv", lang)));
+
+        let count = match format {
+            ExportFormat::Tsv => repo.store().export_tsv(lang, &output_path)?,
+            ExportFormat::Jsonl => repo.store().export_jsonl(lang, &output_path)?,
+            #[cfg(feature = "parquet")]
+            ExportFormat::Parquet => repo.store().export_parquet(lang, &output_path)?,
+        };
+
+        info!(
+            lang,
+            path = %output_path.display(),
+            count,
+            "export complete"
+        );
+        println!("Exported {} entries to {}", count, output_path.display());
+    }
 
     Ok(())
 }

--- a/crates/unimorph-core/src/export.rs
+++ b/crates/unimorph-core/src/export.rs
@@ -218,12 +218,29 @@ impl Store {
     /// ```
     #[instrument(level = "debug", skip(self, path), fields(lang = %lang))]
     pub fn export_tsv<P: AsRef<Path>>(&self, lang: &str, path: P) -> Result<usize> {
-        use std::io::Write;
         debug!(path = %path.as_ref().display(), "exporting to TSV");
-
         let file = std::fs::File::create(path.as_ref())?;
-        let mut writer = std::io::BufWriter::new(file);
+        let writer = std::io::BufWriter::new(file);
+        self.export_tsv_to_writer(lang, writer)
+    }
 
+    /// Export a language dataset to TSV format, writing to a generic writer.
+    ///
+    /// This is useful for writing to stdout or other non-file destinations.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let store = Store::open("datasets.db")?;
+    /// let stdout = std::io::stdout().lock();
+    /// store.export_tsv_to_writer("ita", stdout)?;
+    /// ```
+    #[instrument(level = "debug", skip(self, writer), fields(lang = %lang))]
+    pub fn export_tsv_to_writer<W: std::io::Write>(
+        &self,
+        lang: &str,
+        mut writer: W,
+    ) -> Result<usize> {
         let mut stmt = self
             .conn
             .prepare("SELECT lemma, form, features FROM entries WHERE lang = ?")?;
@@ -257,12 +274,29 @@ impl Store {
     /// ```
     #[instrument(level = "debug", skip(self, path), fields(lang = %lang))]
     pub fn export_jsonl<P: AsRef<Path>>(&self, lang: &str, path: P) -> Result<usize> {
-        use std::io::Write;
         debug!(path = %path.as_ref().display(), "exporting to JSONL");
-
         let file = std::fs::File::create(path.as_ref())?;
-        let mut writer = std::io::BufWriter::new(file);
+        let writer = std::io::BufWriter::new(file);
+        self.export_jsonl_to_writer(lang, writer)
+    }
 
+    /// Export a language dataset to JSON Lines format, writing to a generic writer.
+    ///
+    /// This is useful for writing to stdout or other non-file destinations.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let store = Store::open("datasets.db")?;
+    /// let stdout = std::io::stdout().lock();
+    /// store.export_jsonl_to_writer("ita", stdout)?;
+    /// ```
+    #[instrument(level = "debug", skip(self, writer), fields(lang = %lang))]
+    pub fn export_jsonl_to_writer<W: std::io::Write>(
+        &self,
+        lang: &str,
+        mut writer: W,
+    ) -> Result<usize> {
         let mut stmt = self.conn.prepare(
             "SELECT lemma, form, features FROM entries WHERE lang = ? ORDER BY lemma, form",
         )?;


### PR DESCRIPTION
## Summary

Fixes the `export` command to correctly write to stdout when `-o -` is specified.

## Problem

Previously, `unimorph export -l heb -o - --format tsv` would create a literal file named `-` instead of writing to stdout.

## Solution

- Added `export_tsv_to_writer` and `export_jsonl_to_writer` methods to the core library that accept any `Write` implementation
- Updated the CLI export command to detect `-` as the output path and write to stdout
- Status message ("Exported X entries to stdout") now goes to stderr so it doesn't pollute the data stream

## Testing

```bash
# TSV to stdout
unimorph export -l heb -o - --format tsv | head -5
# Output: actual TSV data

# JSONL to stdout  
unimorph export -l heb -o - --format jsonl | head -5
# Output: actual JSONL data

# Piping works correctly
unimorph export -l heb -o - --format tsv 2>/dev/null | wc -l
# Output: 33177

# Parquet correctly errors
unimorph export -l heb -o - --format parquet
# Error: Cannot export Parquet format to stdout
```