### PR TITLE
feat: add Homebrew formula auto-update to release workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,18 +1,22 @@
-name: Release-plz
+name: Release
 
 permissions:
   pull-requests: write
   contents: write
+  packages: write
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    outputs:
+      releases: ${{ steps.release-plz.outputs.releases }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,10 +24,41 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew Formula
+    runs-on: ubuntu-latest
+    needs: release-plz
+    if: ${{ needs.release-plz.outputs.releases != '[]' && needs.release-plz.outputs.releases != '' }}
+    steps:
+      - name: Parse release info
+        id: parse
+        run: |
+          VERSION=$(echo '${{ needs.release-plz.outputs.releases }}' | jq -r '.[] | select(.package_name == "unimorph-cli") | .version')
+          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+            echo "version=v${VERSION}" >> $GITHUB_OUTPUT
+            echo "Released unimorph-cli version: v${VERSION}"
+          else
+            echo "No unimorph-cli release found"
+            echo "version=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Homebrew formula
+        if: ${{ steps.parse.outputs.version != '' }}
+        uses: mislav/bump-homebrew-formula-action@v3.1
+        with:
+          formula-name: unimorph
+          formula-path: Formula/unimorph.rb
+          base-branch: main
+          tag-name: ${{ steps.parse.outputs.version }}
+          homebrew-tap: joshrotenberg/homebrew-brew
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## Summary
Adds automatic Homebrew formula updates when releases are published.

## Changes
- Extended release-plz.yml with an `update-homebrew` job
- The job triggers after successful releases
- Parses release output to detect unimorph-cli version changes
- Uses `mislav/bump-homebrew-formula-action` to update the formula in `joshrotenberg/homebrew-brew`

## Requirements
- A `COMMITTER_TOKEN` secret must be configured with write access to the homebrew-brew tap repository
- Initial formula (`Formula/unimorph.rb`) needs to be created in the tap repo before the first release

## Initial Formula Template
```ruby
class Unimorph < Formula
  desc "Complete toolkit for working with UniMorph morphological data"
  homepage "https://github.com/joshrotenberg/unimorph-rs"
  url "https://github.com/joshrotenberg/unimorph-rs/archive/refs/tags/v0.1.0.tar.gz"
  sha256 "PLACEHOLDER"
  license "Apache-2.0"

  depends_on "rust" => :build

  def install
    cd "crates/unimorph-cli" do
      system "cargo", "install", *std_cargo_args
    end
  end

  test do
    assert_match "unimorph #{version}", shell_output("#{bin}/unimorph --version")
    assert_match "download", shell_output("#{bin}/unimorph --help")
  end
end
```