### PR TITLE
fix: correct git_release_body type in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,8 +3,12 @@
 changelog_config = "cliff.toml"
 # Create GitHub releases
 git_release_enable = true
-# Include commit body in release notes
-git_release_body = true
+# Git release body template
+git_release_body = """
+{{ changelog }}
+
+**Full Changelog**: https://github.com/joshrotenberg/unimorph-rs/compare/{{ previous_tag }}...{{ tag }}
+"""
 
 # Don't publish the benchmark crate
 [[package]]


### PR DESCRIPTION
## Summary
Fixes the release-plz workflow failure caused by invalid config.

## Problem
The `git_release_body` field was set to `true` (boolean), but release-plz expects a string template.

Error:
```
TOML parse error at line 1, column 1
invalid type: boolean `true`, expected a string
```

## Fix
Changed `git_release_body = true` to a proper template string that includes the changelog and a link to the full diff.