### PR TITLE
fix: add version to unimorph-core dependency for crates.io publishing

### DIFF
--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 parquet = ["unimorph-core/parquet"]
 
 [dependencies]
-unimorph-core = { path = "../unimorph-core" }
+unimorph-core = { path = "../unimorph-core", version = "0.1" }
 clap.workspace = true
 clap_complete = "4"
 tokio.workspace = true


### PR DESCRIPTION
## Summary
Fixes the release workflow failure when publishing unimorph-cli to crates.io.

## Problem
`cargo publish` requires all dependencies to have a version specified. The unimorph-cli crate only had a path dependency on unimorph-core:

```
dependency `unimorph-core` does not specify a version
```

## Fix
Added `version = "0.1"` to the unimorph-core dependency. Cargo will use the local path for development and the version from crates.io when publishing.