### PR TITLE
fix: use correct tag format for Homebrew formula update

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,11 +44,13 @@ jobs:
         run: |
           VERSION=$(echo '${{ needs.release-plz.outputs.releases }}' | jq -r '.[] | select(.package_name == "unimorph-cli") | .version')
           if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            echo "version=v${VERSION}" >> $GITHUB_OUTPUT
-            echo "Released unimorph-cli version: v${VERSION}"
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "tag=unimorph-cli-v${VERSION}" >> $GITHUB_OUTPUT
+            echo "Released unimorph-cli version: ${VERSION} (tag: unimorph-cli-v${VERSION})"
           else
             echo "No unimorph-cli release found"
             echo "version=" >> $GITHUB_OUTPUT
+            echo "tag=" >> $GITHUB_OUTPUT
           fi
 
       - name: Update Homebrew formula
@@ -58,7 +60,8 @@ jobs:
           formula-name: unimorph
           formula-path: Formula/unimorph.rb
           base-branch: main
-          tag-name: ${{ steps.parse.outputs.version }}
+          tag-name: ${{ steps.parse.outputs.tag }}
+          download-url: https://github.com/joshrotenberg/unimorph-rs/archive/refs/tags/${{ steps.parse.outputs.tag }}.tar.gz
           homebrew-tap: joshrotenberg/homebrew-brew
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes the Homebrew formula update failing with HTTP 404.

## Problem
The action was looking for a tag like `v0.1.0` but release-plz creates tags with package prefixes like `unimorph-cli-v0.1.0`.

## Fix
- Changed tag format from `v${VERSION}` to `unimorph-cli-v${VERSION}`
- Added explicit `download-url` parameter to ensure the correct tarball is fetched