### PR TITLE
fix: add readme field to crate manifests for crates.io display

### DIFF
--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 description = "Command-line interface for UniMorph morphological data"
 keywords = ["linguistics", "morphology", "nlp", "unimorph", "cli"]
 categories = ["command-line-utilities", "science", "text-processing"]

--- a/crates/unimorph-core/Cargo.toml
+++ b/crates/unimorph-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 description = "Core library for UniMorph morphological data"
 keywords = ["linguistics", "morphology", "nlp", "unimorph"]
 categories = ["science", "text-processing"]


### PR DESCRIPTION
Adds `readme = "../../README.md"` to both unimorph-core and unimorph-cli Cargo.toml files so the README shows up on crates.io.