### PR TITLE
docs: add links to official UniMorph resources

### DIFF
--- a/docs/src/unimorph/about.md
+++ b/docs/src/unimorph/about.md
@@ -85,7 +85,7 @@ UniMorph uses a standardized feature schema across all languages, making cross-l
 - Tense (PST, PRS, FUT)
 - And many more...
 
-See [Feature Schema](./schema.md) for the complete schema.
+See the [official UniMorph schema documentation](https://unimorph.github.io/doc/unimorph-schema.pdf) for the complete specification, or our [Feature Schema](./schema.md) page for a quick reference.
 
 ## Contributing to UniMorph
 
@@ -115,6 +115,13 @@ If you use UniMorph in research, please cite:
 
 ## Related Projects
 
-- **SIGMORPHON**: Shared tasks on morphological analysis
-- **Universal Dependencies**: Syntactic annotation
-- **Lexical Markup Framework**: ISO standard for lexical resources
+- **[SIGMORPHON](https://sigmorphon.github.io/)**: Shared tasks on morphological analysis
+- **[Universal Dependencies](https://universaldependencies.org/)**: Syntactic annotation
+- **[Lexical Markup Framework](https://www.lexicalmarkupframework.org/)**: ISO standard for lexical resources
+
+## External Links
+
+- [UniMorph Website](https://unimorph.github.io/)
+- [UniMorph GitHub Organization](https://github.com/unimorph)
+- [UniMorph Schema (PDF)](https://unimorph.github.io/doc/unimorph-schema.pdf)
+- [SIGMORPHON Shared Tasks](https://sigmorphon.github.io/sharedtasks/)

--- a/docs/src/unimorph/languages.md
+++ b/docs/src/unimorph/languages.md
@@ -1,6 +1,8 @@
 # Available Languages
 
-UniMorph provides morphological data for 100+ languages. Use `unimorph list --available` to see the current list.
+[UniMorph](https://unimorph.github.io/) provides morphological data for 100+ languages. Use `unimorph list --available` to see the current list.
+
+For the complete list of languages with download links, see the [official UniMorph languages page](https://unimorph.github.io/).
 
 ## Listing Languages
 
@@ -69,7 +71,7 @@ unimorph stats <lang>
 
 ## Language Repositories
 
-Each language has its own GitHub repository under the UniMorph organization:
+Each language has its own GitHub repository under the [UniMorph organization](https://github.com/unimorph):
 
 ```
 https://github.com/unimorph/<code>
@@ -79,6 +81,8 @@ For example:
 - Hebrew: [github.com/unimorph/heb](https://github.com/unimorph/heb)
 - Italian: [github.com/unimorph/ita](https://github.com/unimorph/ita)
 - Finnish: [github.com/unimorph/fin](https://github.com/unimorph/fin)
+
+You can also browse all languages on the [UniMorph website](https://unimorph.github.io/).
 
 ## Data Quality
 
@@ -130,8 +134,8 @@ unimorph inflect -l hebrew כתב
 
 To contribute to a language or add a new one:
 
-1. Visit the language repository on GitHub
+1. Visit the language repository on [GitHub](https://github.com/unimorph)
 2. Check existing issues
 3. Submit corrections or additions via pull request
 
-Or contact the UniMorph team through their website: [unimorph.github.io](https://unimorph.github.io/)
+See the [UniMorph contribution guidelines](https://unimorph.github.io/) for more information.

--- a/docs/src/unimorph/schema.md
+++ b/docs/src/unimorph/schema.md
@@ -1,6 +1,8 @@
 # Feature Schema
 
-UniMorph uses a standardized feature schema to annotate morphological forms. Features are semicolon-separated and position-dependent within each language.
+[UniMorph](https://unimorph.github.io/) uses a standardized feature schema to annotate morphological forms. Features are semicolon-separated and position-dependent within each language.
+
+For the complete official specification, see the [UniMorph Schema documentation (PDF)](https://unimorph.github.io/doc/unimorph-schema.pdf).
 
 ## Feature Format
 
@@ -234,5 +236,8 @@ if features.matches("V;*;SG;*") {
 
 ## References
 
-- [UniMorph Schema Documentation](https://unimorph.github.io/doc/unimorph-schema.pdf)
-- [Leipzig Glossing Rules](https://www.eva.mpg.de/lingua/resources/glossing-rules.php)
+- [UniMorph Schema Documentation (PDF)](https://unimorph.github.io/doc/unimorph-schema.pdf) - Official schema specification
+- [UniMorph Website](https://unimorph.github.io/) - Main project site
+- [UniMorph GitHub](https://github.com/unimorph) - Language repositories
+- [Leipzig Glossing Rules](https://www.eva.mpg.de/lingua/resources/glossing-rules.php) - Standard for interlinear glossing
+- [SIGMORPHON](https://sigmorphon.github.io/) - Shared tasks using UniMorph data


### PR DESCRIPTION
## Summary
Adds proper links to official UniMorph resources throughout the documentation.

## Changes

### languages.md
- Link to UniMorph website for complete language list
- Link to UniMorph GitHub organization
- Updated contribution section with proper links

### about.md
- Link to official schema PDF
- Added links to related projects (SIGMORPHON, Universal Dependencies, LMF)
- Added External Links section with key UniMorph URLs

### schema.md
- Link to official schema documentation
- Expanded references section with more resources

## Links Added
- https://unimorph.github.io/ (main site)
- https://unimorph.github.io/doc/unimorph-schema.pdf (schema spec)
- https://github.com/unimorph (GitHub org)
- https://sigmorphon.github.io/ (related project)