### PR TITLE
ci: rename release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release-plz
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Rename release-plz workflow to 'Release-plz' to avoid conflict with cargo-dist 'Release' workflow.