### PR TITLE
fix: minor formatting in version string

### DIFF
--- a/crates/unimorph-cli/src/main.rs
+++ b/crates/unimorph-cli/src/main.rs
@@ -36,7 +36,8 @@ fn no_language_error() -> color_eyre::eyre::Report {
 
 const LONG_VERSION: &str = concat!(
     env!("CARGO_PKG_VERSION"),
-    "\nhttps://github.com/joshrotenberg/unimorph-rs"
+    "\n",
+    "https://github.com/joshrotenberg/unimorph-rs"
 );
 
 #[derive(Parser)]


### PR DESCRIPTION
Splits the version string concatenation for clarity. This triggers a new release to test the updated cargo-dist workflow with PyO3 compatibility and the new Docker build.