### PR TITLE
fix: use rust:latest for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Multi-stage build for unimorph CLI
-FROM rust:1.85-slim-bookworm AS builder
+# Requires Rust 1.85+ for 2024 edition support
+FROM rust:latest AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
The Docker build was failing because `rust:1.85-slim-bookworm` doesn't have Rust 1.85 - Docker Hub's latest stable Rust image is still behind. The codebase uses Rust 2024 edition features (if-let chains) that require Rust 1.85+.

This changes to `rust:latest` which should have a recent enough Rust version.