### PR TITLE
fix: auto re-push tags to trigger release workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -30,7 +31,7 @@ jobs:
         id: release-plz
         uses: release-plz/action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   update-homebrew:


### PR DESCRIPTION
Adds a `trigger-release` job to the release-plz workflow that re-pushes tags after they're created.

**Problem:** release-plz creates tags via the GitHub API, which doesn't trigger `push: tags` workflows. This means the Release (cargo-dist) and Docker workflows don't run automatically.

**Solution:** After release-plz creates releases, this new job:
1. Parses the released packages from release-plz output
2. Re-pushes each tag (delete + push) to trigger the tag-based workflows

This eliminates the need to manually re-push tags after each release.