### PR TITLE
docs: document transparent compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Rust toolkit for working with [UniMorph](https://unimorph.github.io/) morpholo
 
 ## What is UniMorph?
 
-UniMorph provides morphological paradigm data for 169+ languages in a unified annotation format. Each entry is a triple of lemma, inflected form, and morphological features:
+UniMorph provides morphological paradigm data for 180+ languages in a unified annotation format. Each entry is a triple of lemma, inflected form, and morphological features:
 
 ```
 lemma       form        features
@@ -49,6 +49,14 @@ git clone https://github.com/joshrotenberg/unimorph-rs
 cd unimorph-rs
 cargo install --path crates/unimorph-cli  # directory still named unimorph-cli
 ```
+
+## Features
+
+- **Automatic downloads** from UniMorph GitHub repositories
+- **Transparent decompression** of `.xz`, `.gz`, and `.zip` files (some large datasets are compressed)
+- **SQLite storage** for fast local queries
+- **Multiple export formats**: TSV, JSON Lines, Parquet
+- **Python bindings** via PyO3
 
 ## Quick Start
 

--- a/docs/src/cli/download.md
+++ b/docs/src/cli/download.md
@@ -90,6 +90,7 @@ unimorph download  # Downloads Hebrew
 - Use `unimorph list --available` to see all available languages
 - Downloads are atomic: partial downloads won't corrupt your data
 - The first download creates the database at `~/.cache/unimorph/datasets.db`
+- **Compressed files are handled automatically**: Some large datasets (e.g., Polish, Czech, Ukrainian) are distributed as `.xz` compressed files. The CLI transparently downloads and decompresses these.
 
 ## See Also
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-**unimorph-rs** is a complete Rust toolkit for working with [UniMorph](https://unimorph.github.io/) morphological data. It provides both a command-line interface and a Rust library for downloading, querying, and analyzing morphological inflection data across 100+ languages.
+**unimorph-rs** is a complete Rust toolkit for working with [UniMorph](https://unimorph.github.io/) morphological data. It provides both a command-line interface and a Rust library for downloading, querying, and analyzing morphological inflection data across 180+ languages.
 
 ## What is UniMorph?
 
@@ -18,7 +18,8 @@ For example, in Spanish:
 ## Features
 
 - **Fast lookups**: SQLite-backed storage with indexed queries
-- **100+ languages**: Access to all UniMorph language datasets
+- **180+ languages**: Access to all UniMorph language datasets
+- **Transparent decompression**: Handles `.xz`, `.gz`, and `.zip` compressed datasets automatically
 - **Flexible querying**: Search by lemma, form, features, or part of speech
 - **Multiple output formats**: Table, JSON, TSV for scripting
 - **Pipe-friendly**: Output designed for Unix pipelines

--- a/docs/src/library/repository.md
+++ b/docs/src/library/repository.md
@@ -31,6 +31,16 @@ repo.download("heb").await?;
 repo.download_with_options("heb", true).await?;
 ```
 
+### Compressed Files
+
+Some large datasets (Polish, Czech, Ukrainian, etc.) are distributed as compressed `.xz` files due to GitHub file size limits. The repository automatically:
+
+1. Tries compressed versions first (`.xz`, `.gz`)
+2. Falls back to uncompressed if not found
+3. Decompresses transparently before importing
+
+No special handling is needed - just call `download()` as usual.
+
 ## Accessing the Store
 
 Get the underlying store for queries:


### PR DESCRIPTION
Documents the compression support added in #83.

## Changes

- Update language count to 180+ (based on repository survey)
- Add "transparent decompression" to feature lists in README and introduction
- Document automatic .xz/.gz/.zip handling in CLI download docs
- Add "Compressed Files" section to library repository docs

## Related

- #83 - feat: add transparent decompression for compressed UniMorph files