### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,7 +5039,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unimorph"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "unimorph-bench"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "dirs",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "unimorph-core"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "arrow 54.3.1",
  "dirs",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "unimorph-python"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85.0"
 license = "Apache-2.0"

--- a/crates/unimorph-cli/CHANGELOG.md
+++ b/crates/unimorph-cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-01-19
+
+### Documentation
+
+- Document transparent compression support ([#85](https://github.com/joshrotenberg/unimorph-rs/pull/85))
+
+
+
 ## [0.1.8] - 2026-01-07
 
 ### Bug Fixes

--- a/crates/unimorph-cli/Cargo.toml
+++ b/crates/unimorph-cli/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 parquet = ["unimorph-core/parquet"]
 
 [dependencies]
-unimorph-core = { path = "../unimorph-core", version = "0.1" }
+unimorph-core = { path = "../unimorph-core", version = "0.2" }
 clap.workspace = true
 clap_complete = "4"
 tokio.workspace = true

--- a/crates/unimorph-core/CHANGELOG.md
+++ b/crates/unimorph-core/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-01-19
+
+### Documentation
+
+- Document transparent compression support ([#85](https://github.com/joshrotenberg/unimorph-rs/pull/85))
+
+### Features
+
+- Add transparent decompression for compressed UniMorph files ([#83](https://github.com/joshrotenberg/unimorph-rs/pull/83))
+- Add Git LFS support for large files ([#86](https://github.com/joshrotenberg/unimorph-rs/pull/86))
+
+
+
 ## [0.1.8] - 2026-01-07
 
 


### PR DESCRIPTION



## 🤖 New release

* `unimorph-core`: 0.1.8 -> 0.2.0 (⚠ API breaking changes)
* `unimorph`: 0.1.8 -> 0.2.0

### ⚠ `unimorph-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:DecompressionFailed in /tmp/.tmpyvyQjs/unimorph-rs/crates/unimorph-core/src/error.rs:34
  variant Error:DecompressionFailed in /tmp/.tmpyvyQjs/unimorph-rs/crates/unimorph-core/src/error.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `unimorph-core`

<blockquote>

## [0.2.0] - 2026-01-19

### Documentation

- Document transparent compression support ([#85](https://github.com/joshrotenberg/unimorph-rs/pull/85))

### Features

- Add transparent decompression for compressed UniMorph files ([#83](https://github.com/joshrotenberg/unimorph-rs/pull/83))
- Add Git LFS support for large files ([#86](https://github.com/joshrotenberg/unimorph-rs/pull/86))
</blockquote>

## `unimorph`

<blockquote>

## [0.2.0] - 2026-01-19

### Documentation

- Document transparent compression support ([#85](https://github.com/joshrotenberg/unimorph-rs/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).