### PR TITLE
fix: correct README CLI examples and handle trailing tabs in TSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ cargo install --path crates/unimorph-cli  # directory still named unimorph-cli
 unimorph download spa
 
 # Look up all forms of a verb
-unimorph inflect spa hablar
+unimorph inflect -l spa hablar
 
 # Analyze a surface form (reverse lookup)
-unimorph analyze spa hablo
+unimorph analyze -l spa hablo
 
 # Search with filters
-unimorph search spa --lemma "habl*" --contains V,IND
+unimorph search -l spa --lemma "habl%" --contains V,IND
 
 # Dataset statistics
 unimorph stats spa

--- a/crates/unimorph-core/src/types.rs
+++ b/crates/unimorph-core/src/types.rs
@@ -260,12 +260,17 @@ impl Entry {
         let lemma = parts[0];
         let form = parts[1];
         // Merge columns 3+ into features (some languages have extra feature columns)
+        // Filter out empty parts to handle trailing tabs (e.g., "lemma\tform\tfeatures\t")
         let features_str = if parts.len() > 3 {
-            parts[2..].join(";")
+            parts[2..]
+                .iter()
+                .filter(|p| !p.is_empty())
+                .copied()
+                .collect::<Vec<_>>()
+                .join(";")
         } else {
             parts[2].to_string()
         };
-        let features_str = features_str.as_str();
 
         if lemma.is_empty() {
             return Err(Error::MalformedEntry {
@@ -281,7 +286,7 @@ impl Entry {
             });
         }
 
-        let features = FeatureBundle::new(features_str).map_err(|_| Error::MalformedEntry {
+        let features = FeatureBundle::new(&features_str).map_err(|_| Error::MalformedEntry {
             line: line_num,
             reason: format!("invalid features: {}", features_str),
         })?;
@@ -534,6 +539,15 @@ mod tests {
             assert_eq!(entry.lemma, "lemma");
             assert_eq!(entry.form, "form");
             assert_eq!(entry.features.as_str(), "N;ACC;SG;MASC;INAN");
+        }
+
+        #[test]
+        fn trailing_tab_ignored() {
+            // Czech files have trailing tabs (e.g., "lemma\tform\tfeatures\t")
+            let entry = Entry::parse_line("lemma\tform\tADJ;FEM;INS;DU\t", 1).unwrap();
+            assert_eq!(entry.lemma, "lemma");
+            assert_eq!(entry.form, "form");
+            assert_eq!(entry.features.as_str(), "ADJ;FEM;INS;DU");
         }
 
         #[test]


### PR DESCRIPTION
## Changes

### README fixes
- Fix CLI examples to use `-l/--lang` flag for `analyze`, `search`, `inflect` commands
- Use SQL LIKE wildcard (`%`) instead of glob (`*`) in search example

### Parser fix
- Handle trailing tabs in TSV files. Czech (`ces.xz`) has a trailing tab on every line, which was causing 35.8 million entries to be rejected as malformed due to empty feature detection.
- Before: 14.5M imported, 35.8M skipped
- After: 50.3M imported, 0 skipped

### Tests
- Add test for trailing tab handling