### PR TITLE
fix: disable release-plz GitHub release to avoid cargo-dist conflict

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,11 +1,5 @@
 [workspace]
 # Use git-cliff for changelog generation
 changelog_config = "cliff.toml"
-# Create GitHub releases
-git_release_enable = true
-# Git release body template
-git_release_body = """
-{{ changelog }}
-
-**Full Changelog**: https://github.com/joshrotenberg/unimorph-rs/compare/{{ previous_tag }}...{{ tag }}
-"""
+# Disable GitHub release creation - cargo-dist handles this with binary artifacts
+git_release_enable = false


### PR DESCRIPTION
## Problem

When release-plz merges the release PR, it creates a GitHub release (empty, no artifacts). Then cargo-dist's workflow triggers on the tag push and tries to `gh release create`, but fails with:

```
a release with the same tag name already exists: unimorph-v0.2.1
```

This prevents binaries from being attached, Homebrew from updating, and the announce step from running.

## Solution

Disable `git_release_enable` in release-plz.toml. Let cargo-dist handle GitHub release creation since it attaches the binary artifacts.

## Flow after this change

1. release-plz creates/updates the release PR with changelog
2. release-plz merges the PR and pushes the tag (no GitHub release)
3. cargo-dist triggers on tag, builds artifacts, creates GitHub release with binaries
4. cargo-dist updates Homebrew and runs announce step